### PR TITLE
Set mysql connection charset=utf8

### DIFF
--- a/src/api/ProjectController.php
+++ b/src/api/ProjectController.php
@@ -30,7 +30,6 @@ class ProjectController
                     'name'
                 )
             ));
-            $asArray['name'] = utf8_encode($asArray['name']);
             $asArray['type'] = $project->type();
             $canEncode = json_encode($asArray);
             if ($canEncode === false) {
@@ -54,7 +53,6 @@ class ProjectController
     {
         $project = Project::find($id);
         $asArray = $project->to_array();
-        $asArray['name'] = utf8_encode($asArray['name']);
         $canEncode = json_encode($asArray);
         if ($canEncode === false) {
             throw new \Exception("Cannot encode to json");

--- a/src/index.php
+++ b/src/index.php
@@ -20,8 +20,8 @@ $app->register(new TwigServiceProvider(), array(
 $app->register(new ActiveRecordServiceProvider(), array(
     'ActiveRecord.modelPath' => __DIR__ . '/api/Models',
     'ActiveRecord.connections' => array(
-        'public' => 'mysql://' . DB_USER . ':' . DB_PASS . '@localhost/languagedepot',
-        'private' => 'mysql://' . DB_USER . ':' . DB_PASS . '@localhost/languagedepotpvt'
+        'public' => 'mysql://' . DB_USER . ':' . DB_PASS . '@localhost/languagedepot;charset=utf8',
+        'private' => 'mysql://' . DB_USER . ':' . DB_PASS . '@localhost/languagedepotpvt;charset=utf8'
     ),
     'ActiveRecord.defaultConnection' => 'public'
 ));

--- a/test/php/TestEnvironment.php
+++ b/test/php/TestEnvironment.php
@@ -10,8 +10,8 @@ class TestEnvironment
             {
                 $cfg->set_model_directory(SRC_PATH . '/api/Models');
                 $cfg->set_connections(array(
-                    'public' => 'mysql://' . DB_USER . ':' . DB_PASS . '@localhost/languagedepot',
-                    'private' => 'mysql://' . DB_USER . ':' . DB_PASS . '@localhost/languagedepotpvt'
+                    'public' => 'mysql://' . DB_USER . ':' . DB_PASS . '@localhost/languagedepot;charset=utf8',
+                    'private' => 'mysql://' . DB_USER . ':' . DB_PASS . '@localhost/languagedepotpvt;charset=utf8'
                 ));
                 $cfg->set_default_connection('public');
             });

--- a/test/php/api/ProjectControllerTest.php
+++ b/test/php/api/ProjectControllerTest.php
@@ -127,11 +127,11 @@ class ProjectControllerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testGetProjectAccess_ProjectNameUTF8Encoded_OK() {
+    public function testGetProjectAccess_FieldsUTF8Encoded_OK() {
         $controller = new ProjectController();
 
         // Get by id
-        $id = '2';
+        $id = '7';
         $result = $controller->get($id);
         $result = json_decode($result);
         $result->created_on = ApiTestEnvironment::StripTimeZone($result->created_on);
@@ -139,30 +139,18 @@ class ProjectControllerTest extends PHPUnit_Framework_TestCase
 
         $expected = new \stdclass();
         $expected->id = $id;
-        $expected->name = 'LD Test Dictioñary';
-        $expected->description = 'LD API Test Dictionary project';
+        $expected->name = 'LD API UTF8 Eñcoding';
+        $expected->description = 'LD API Test UTF8 Eñcoding project';
         $expected->homepage = '';
         $expected->is_public = 1;
         $expected->parent_id = null;
         $expected->projects_count = 0;
-        $expected->created_on = '2011-07-24T05:24:19';
-        $expected->updated_on = '2017-02-24T02:33:33';
-        $expected->identifier = 'test-ld-dictionary';
+        $expected->created_on = '2016-08-10T07:30:45';
+        $expected->updated_on = '2017-03-01T08:10:20';
+        $expected->identifier = 'test-ld-ütf8';
         $expected->status = 1;
 
         $this->assertEquals($expected, $result);
-    }
-
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     * @expectedExceptionMessage json
-     */
-    public function testGet_DescriptionNotUTF8Encoded_Exception() {
-        $controller = new ProjectController();
-
-        // Get by id
-        $id = 7;
-        $result = $controller->get($id);
     }
 
     public function testProjectCodeIsAvailable_CodeExists_False() {

--- a/test/php/api/UserControllerTest.php
+++ b/test/php/api/UserControllerTest.php
@@ -74,7 +74,7 @@ class UserControllerTest extends PHPUnit_Framework_TestCase
 
         $expected0 = new \stdclass;
         $expected0->identifier = 'test-ld-dictionary';
-        $expected0->name = 'LD Test Dictioñary';
+        $expected0->name = 'LD Test Dictionary';
         $expected0->repository = 'http://public.languagedepot.org';
         $expected0->role = 'contributor';
         $expected1 = new \stdclass;
@@ -129,7 +129,7 @@ class UserControllerTest extends PHPUnit_Framework_TestCase
 
         $expected0 = new \stdclass;
         $expected0->identifier = 'test-ld-dictionary';
-        $expected0->name = 'LD Test Dictioñary';
+        $expected0->name = 'LD Test Dictionary';
         $expected0->repository = 'http://public.languagedepot.org';
         $expected0->role = 'contributor';
         $expected = array($expected0);

--- a/test/php/api/UserTest.php
+++ b/test/php/api/UserTest.php
@@ -58,7 +58,7 @@ class UserTest extends PHPUnit_Framework_TestCase
 
         $expected0 = new \stdclass;
         $expected0->identifier = 'test-ld-dictionary';
-        $expected0->name = 'LD Test Dictioñary';
+        $expected0->name = 'LD Test Dictionary';
         $expected0->repository = 'http://public.languagedepot.org';
         $expected0->role = 'contributor';
         $expected1 = new \stdclass;

--- a/test/testlanguagedepot.sql
+++ b/test/testlanguagedepot.sql
@@ -533,12 +533,12 @@ CREATE TABLE `projects` (
 
 INSERT INTO `projects` (`id`, `name`, `description`, `homepage`, `is_public`, `parent_id`, `projects_count`, `created_on`, `updated_on`, `identifier`, `status`) VALUES
 (1, 'LD Test', 'LD API Test project', '', 0, NULL, 0, '2009-07-23 09:56:52', '2017-02-24 09:56:52', 'ld-test', 1),
-(2, 'LD Test Dictioñary', 'LD API Test Dictionary project', '', 1, NULL, 0, '2011-07-24 05:24:19', '2017-02-24 02:33:33', 'test-ld-dictionary', 1),
+(2, 'LD Test Dictionary', 'LD API Test Dictionary project', '', 1, NULL, 0, '2011-07-24 05:24:19', '2017-02-24 02:33:33', 'test-ld-dictionary', 1),
 (3, 'LD API Test Flex', 'LD API Test FLEx project', '', 1, NULL, 0, '2012-09-21 02:44:47', '2017-02-24 02:44:47', 'test-ld-flex', 1),
 (4, 'LD API Test Demo', 'LD API Test Demo project', '', 1, NULL, 0, '2013-09-21 02:44:47', '2017-02-24 02:44:47', 'test-ld-demo', 1),
 (5, 'LD API Test AdaptIT', 'LD API Test AdaptIT project', '', 1, NULL, 0, '2014-09-21 02:44:47', '2017-02-24 02:44:47', 'test-ld-adapt', 1),
 (6, 'LD API Test Training', 'LD API Test Training project', '', 1, NULL, 0, '2015-09-21 02:44:47', '2017-02-24 02:44:47', 'test-ld-training', 1),
-(7, 'LD API UTF8 Eñcoding', 'LD API Test UTF8 Eñcoding', '', 0, NULL, 0, '2016-08-10 07:30:45', '2017-03-01 08:10:20', 'test-ld-utf8', 1);
+(7, 'LD API UTF8 Eñcoding', 'LD API Test UTF8 Eñcoding project', '', 1, NULL, 0, '2016-08-10 07:30:45', '2017-03-01 08:10:20', 'test-ld-ütf8', 1);
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
Previously, ProjectController had to wrap individual fields with `utf_encode()` to ensure `json_encode()` could handle special characters.

Setting the mysql connection with `charset=utf8` ensures all the fields in the stream will be safely encoded.

-Designate test project id=7 for testing utf8 encoding

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languagedepot-api/5)
<!-- Reviewable:end -->
