### PR TITLE
Handle both public and private DB instances

### DIFF
--- a/src/Server/Controller.fs
+++ b/src/Server/Controller.fs
@@ -112,6 +112,10 @@ let listUsers : HttpHandler =
     withServiceFunc true
         (fun connString (listUsers : Model.ListUsers) -> listUsers connString None None)
 
+let listUsersPrivate : HttpHandler =
+    withServiceFunc false
+        (fun connString (listUsers : Model.ListUsers) -> listUsers connString None None)
+
 let listUsersLimit limit : HttpHandler =
     withServiceFunc true
         (fun connString (listUsers : Model.ListUsers) -> listUsers connString (Some limit) None)

--- a/src/Server/Controller.fs
+++ b/src/Server/Controller.fs
@@ -236,7 +236,7 @@ let addOrRemoveUserFromProject projectCode (patchData : Api.EditProjectMembershi
 
 let getAllRoles : HttpHandler =
     withServiceFunc true
-        (fun connString (roleNames : Model.ListRoles) -> roleNames connString ())
+        (fun connString (roleNames : Model.ListRoles) -> roleNames connString)
 
 let createUser (user : Api.CreateUser) : HttpHandler = fun (next : HttpFunc) (ctx : HttpContext) -> task {
     // Can't use withServiceFunc for this one since we need to do extra work in the success branch
@@ -283,21 +283,21 @@ let countUsers : HttpHandler =
     withServiceFunc true
         (fun connString (Model.CountUsers countUsers) -> async {
                 do! Async.Sleep 500 // Simulate server load
-                return! countUsers connString ()
+                return! countUsers connString
         })
 
 let countProjects : HttpHandler =
     withServiceFunc true
         (fun connString (Model.CountProjects countProjects) -> async {
                 do! Async.Sleep 750 // Simulate server load
-                return! countProjects connString ()
+                return! countProjects connString
         })
 
 let countRealProjects : HttpHandler =
     withServiceFunc true
         (fun connString (Model.CountRealProjects countRealProjects) -> async {
                 do! Async.Sleep 1000 // Simulate server load
-                return! countRealProjects connString ()
+                return! countRealProjects connString
         })
 
 let getMySqlSettings : HttpHandler = fun (next : HttpFunc) (ctx : HttpContext) -> task {

--- a/src/Server/MemoryModel.fs
+++ b/src/Server/MemoryModel.fs
@@ -18,11 +18,11 @@ let listProjects : Model.ListProjects = fun _connString -> async {
     return MemoryStorage.projectStorage.Values |> List.ofSeq
 }
 
-let countUsers = Model.CountUsers (fun _connString () -> async {
+let countUsers = Model.CountUsers (fun _connString -> async {
     return MemoryStorage.userStorage.Count
 })
 
-let countProjects = Model.CountProjects (fun _connString () -> async {
+let countProjects = Model.CountProjects (fun _connString -> async {
     return MemoryStorage.projectStorage.Count
 })
 
@@ -30,11 +30,11 @@ let isRealProject (proj : Dto.ProjectDetails) =
     let projType = GuessProjectType.guessType proj.code proj.name proj.description
     projType <> Test && not (proj.code.StartsWith "test")
 
-let countRealProjects = Model.CountRealProjects (fun _connString () -> async {
+let countRealProjects = Model.CountRealProjects (fun _connString -> async {
     return MemoryStorage.projectStorage.Values |> Seq.filter isRealProject |> Seq.length
 })
 
-let listRoles : Model.ListRoles = fun _connString () -> async {
+let listRoles : Model.ListRoles = fun _connString -> async {
     return Dto.standardRoles
 }
 

--- a/src/Server/Model.fs
+++ b/src/Server/Model.fs
@@ -81,10 +81,10 @@ type Dto.RoleDetails with
 type ListUsers = string -> int option -> int option -> Async<Dto.UserDetails list>
 type ListProjects = string -> Async<Dto.ProjectList>
 // These three CountFoo types all look the same, so we have to use a single-case DU to distinguish them
-type CountUsers = CountUsers of (string -> unit -> Async<int>)
-type CountProjects = CountProjects of (string -> unit -> Async<int>)
-type CountRealProjects = CountRealProjects of (string -> unit -> Async<int>)
-type ListRoles = string -> unit -> Async<Dto.RoleDetails list>
+type CountUsers = CountUsers of (string -> Async<int>)
+type CountProjects = CountProjects of (string -> Async<int>)
+type CountRealProjects = CountRealProjects of (string -> Async<int>)
+type ListRoles = string -> Async<Dto.RoleDetails list>
 type ProjectsByUser = string -> string -> Async<Dto.ProjectDetails list>
 type ProjectsByUserRole = string -> string -> RoleType -> Async<Dto.ProjectDetails list>
 type ProjectsAndRolesByUser = string -> string -> Async<(Dto.ProjectDetails * RoleType list) list>
@@ -184,7 +184,7 @@ let projectsAndRolesQueryAsync (connString : string) =
         return projectsAndRoles |> List.groupBy (fun (project, _, _, _) -> project.Identifier) |> List.choose (snd >> Dto.ProjectDetails.FromSqlWithRoles)
     }
 
-let projectsCountAsync (connString : string) () =
+let projectsCountAsync (connString : string) =
     async {
         let ctx = sql.GetDataContext connString
         return query {
@@ -194,7 +194,7 @@ let projectsCountAsync (connString : string) () =
         }
     }
 
-let realProjectsCountAsync (connString : string) () =
+let realProjectsCountAsync (connString : string) =
     async {
         let! projects = projectsQueryAsync connString
         return
@@ -204,7 +204,7 @@ let realProjectsCountAsync (connString : string) () =
             |> Seq.length
     }
 
-let usersCountAsync (connString : string) () =
+let usersCountAsync (connString : string) =
     async {
         let ctx = sql.GetDataContext connString
         return query {
@@ -419,7 +419,7 @@ let projectsByUser connString username = async {
     return projectsAndRoles |> List.map fst
 }
 
-let roleNames (connString : string) () =
+let roleNames (connString : string) =
     async {
         let ctx = sql.GetDataContext connString
         let roleQuery = query {

--- a/src/Server/Server.fs
+++ b/src/Server/Server.fs
@@ -39,6 +39,7 @@ let webApp = router {
     getf "/api/project/%s" Controller.getPublicProject
     // TODO: Not in real API spec. Why not? Probably need to add it
     get "/api/users" Controller.listUsers
+    get "/api/privateUsers" Controller.listUsersPrivate  // TODO: Test-only. Remove before going to production.
     getf "/api/users/limit/%i" Controller.listUsersLimit
     getf "/api/users/offset/%i" Controller.listUsersOffset
     getf "/api/users/limit/%i/offset/%i" Controller.listUsersLimitOffset

--- a/src/Shared/Settings.fs
+++ b/src/Shared/Settings.fs
@@ -7,7 +7,9 @@ module Settings =
     type MySqlSettings = {
         Hostname : string
         Database : string
+        DatabasePrivate : string
         Password : string
+        PasswordPrivate : string
         Port : int
         User : string
     } with
@@ -15,7 +17,9 @@ module Settings =
           printfn "Setting default values for %A" this
           { Hostname = this.Hostname |> defaultValue "default hostname"
             Database = this.Database |> defaultValue "default database"
+            DatabasePrivate = this.DatabasePrivate |> defaultValue "default private database"
             Password = this.Password |> defaultValue ""
+            PasswordPrivate = this.PasswordPrivate |> defaultValue (this.Password |> defaultValue "")
             Port = this.Port |> defaultEnvParsed System.Int32.Parse "PORT" 3306
             User = this.User |> defaultEnv "USER" "mysql" }
         member this.ConnString =
@@ -23,3 +27,8 @@ module Settings =
                 sprintf "Server=%s;Database=%s;Uid=%s" this.Hostname this.Database this.User
             else
                 sprintf "Server=%s;Database=%s;Uid=%s;Pwd=%s" this.Hostname this.Database this.User this.Password
+        member this.ConnStringPrivate =
+            if System.String.IsNullOrEmpty this.PasswordPrivate then
+                sprintf "Server=%s;Database=%s;Uid=%s" this.Hostname this.DatabasePrivate this.User
+            else
+                sprintf "Server=%s;Database=%s;Uid=%s;Pwd=%s" this.Hostname this.DatabasePrivate this.User this.PasswordPrivate


### PR DESCRIPTION
Previous code was written in such a way that the database name in the code had to match the name in the connection string. I've now found the SQLProvider option that lets you explicitly specify the database name to use in the code, so I'm now free to change the database name in the connection string. This will allow connecting to both public and private databases (with names taken from the config file). It will also allow creating a test database like `testldapi` for acceptance tests, so that we can run acceptance tests on the QA server without blowing away the "main" database on the QA server every time we run a test. (We'd probably also run the acceptance tests in a different server instance listening on a different port, using the `SERVER_PORT` environment variable, to completely isolate the acceptance tests from the main server.)