### PR TITLE
Simplify project membership

### DIFF
--- a/src/Client/AllProjectsPage.fs
+++ b/src/Client/AllProjectsPage.fs
@@ -31,7 +31,7 @@ type Msg =
 type Model = { FoundProjects : Dto.ProjectList; IsAdmin : bool }  // TODO: Handle case where we also have roles
 
 let init() =
-    { FoundProjects = []; IsAdmin = false }, Cmd.none
+    { FoundProjects = [||]; IsAdmin = false }, Cmd.none
 
 let update (msg : Msg) (currentModel : Model) : Model * Cmd<Msg> =
     match msg with
@@ -60,12 +60,12 @@ let update (msg : Msg) (currentModel : Model) : Model * Cmd<Msg> =
     | ProjectsAndRolesFound result ->
         unpackJsonResult currentModel result (fun projects ->
             // For some reason, List.map isn't working right so we use Seq.map here
-            let nextModel = { currentModel with FoundProjects = projects |> Seq.map (fun (project, roles) -> project) |> List.ofSeq }
-            nextModel, Cmd.ofMsg (LogProjectResult (projects |> Seq.map (fun (project, roles) -> project) |> List.ofSeq)))
+            let nextModel = { currentModel with FoundProjects = projects |> Seq.map (fun (project, roles) -> project) |> Array.ofSeq }
+            nextModel, Cmd.ofMsg (LogProjectResult (projects |> Seq.map (fun (project, roles) -> project) |> Array.ofSeq)))
     | SingleProjectFound result ->
         unpackJsonResult currentModel result (fun project ->
-            let nextModel = { currentModel with FoundProjects = [project] }
-            nextModel, Cmd.ofMsg (LogProjectResult [project]))
+            let nextModel = { currentModel with FoundProjects = [|project|] }
+            nextModel, Cmd.ofMsg (LogProjectResult [|project|]))
     | ProjectNotFound ->
         currentModel, Cmd.none
     | LogProjectResult projects ->

--- a/src/Client/AllUsersPage.fs
+++ b/src/Client/AllUsersPage.fs
@@ -88,7 +88,7 @@ let update (msg : Msg) (currentModel : Model) : Model * Cmd<Msg> =
         currentModel, Cmd.none
     | LogUserResult users ->
         for user in users do
-            printfn "Username %s, first name %s, last name %s, email(s) %A" user.username user.firstName user.lastName user.emailAddresses
+            printfn "Username %s, first name %s, last name %s, email(s) %A" user.username user.firstName user.lastName user.email
         currentModel, Cmd.none
     | LogException exn ->
         let cmd = Notifications.notifyError exn.Message

--- a/src/Client/AllUsersPage.fs
+++ b/src/Client/AllUsersPage.fs
@@ -34,7 +34,7 @@ type Msg =
 type Model = { FoundUsers : Dto.UserList; SearchResults : Dto.UserList; UsersPerPage : int; UserCount : int; CurrentPage : int; IsAdmin : bool }
 
 let init() =
-    { FoundUsers = []; SearchResults = []; UsersPerPage = 25; UserCount = 0; CurrentPage = 1; IsAdmin = false },
+    { FoundUsers = [||]; SearchResults = [||]; UsersPerPage = 25; UserCount = 0; CurrentPage = 1; IsAdmin = false },
     Cmd.OfPromise.perform Fetch.get "/api/count/users" UserCountLoaded
 
 let update (msg : Msg) (currentModel : Model) : Model * Cmd<Msg> =

--- a/src/Client/Client.fs
+++ b/src/Client/Client.fs
@@ -118,7 +118,7 @@ let update (msg : Msg) (currentModel : Model) : Model * Cmd<Msg> =
     | _, UrlChanged parts ->
         let page, cmd = Nav.parseUrl parts
         let nextModel = { currentModel with Page = page }
-        nextModel, Cmd.batch [ cmd; Cmd.ofMsg (RootPageMsg RootPage.Msg.RefreshCounts) ]
+        nextModel, cmd
     // Sub pages
     | { RootModel = rootModel }, RootPageMsg rootMsg ->
         let nextRootModel, nextRootCmds = rootModel |> RootPage.update rootMsg

--- a/src/Client/MockServer.fs
+++ b/src/Client/MockServer.fs
@@ -11,7 +11,7 @@ let getAllUsers() = async {
 }
 
 let getUser username = async {
-    return SampleData.Users |> List.tryFind (fun user -> user.username = username) |> success
+    return SampleData.Users |> Array.tryFind (fun user -> user.username = username) |> success
 }
 
 // TODO: Continue writing this

--- a/src/Client/SingleUserPage.fs
+++ b/src/Client/SingleUserPage.fs
@@ -121,7 +121,7 @@ let RoleSelector =
         // TODO: Find out why React is making "Manager" selected by default, despite the line above
         Select.select
             [ Select.IsLoading (props.model.RoleList |> List.isEmpty) ]
-            [ select [ OnChange (fun ev -> selected.update ev.Value) ] [ for role in props.model.RoleList -> option [ Value (role.``type``.ToString()); Key (role.``type``.ToString()) ] [ str (role.name) ] ]
+            [ select [ OnChange (fun ev -> selected.update ev.Value) ] [ for role in props.model.RoleList -> option [ Value (role.name); Key (role.id.ToString()) ] [ str (role.name) ] ]
               Button.a
                 [ Button.Size IsSmall
                   Button.Color IsPrimary

--- a/src/Server/MemoryModel.fs
+++ b/src/Server/MemoryModel.fs
@@ -21,11 +21,11 @@ let listProjects : Model.ListProjects = fun _connString -> task {
 }
 
 let countUsers = Model.CountUsers (fun _connString -> task {
-    return MemoryStorage.userStorage.Count
+    return int64 MemoryStorage.userStorage.Count
 })
 
 let countProjects = Model.CountProjects (fun _connString -> task {
-    return MemoryStorage.projectStorage.Count
+    return int64 MemoryStorage.projectStorage.Count
 })
 
 let isRealProject (proj : Dto.ProjectDetails) =
@@ -33,7 +33,7 @@ let isRealProject (proj : Dto.ProjectDetails) =
     projType <> Test && not (proj.code.StartsWith "test")
 
 let countRealProjects = Model.CountRealProjects (fun _connString -> task {
-    return MemoryStorage.projectStorage.Values |> Seq.filter isRealProject |> Seq.length
+    return MemoryStorage.projectStorage.Values |> Seq.filter isRealProject |> Seq.length |> int64
 })
 
 let listRoles : Model.ListRoles = fun _connString -> task {

--- a/src/Server/MemoryStorage.fs
+++ b/src/Server/MemoryStorage.fs
@@ -30,18 +30,18 @@ let storeNewPassword username cleartextPassword =
         (fun _ -> let salt = createSalt (Guid.NewGuid()) in { salt = salt; hashedPassword = hashPassword salt cleartextPassword }),
         (fun _ oldPassword -> { oldPassword with hashedPassword = hashPassword oldPassword.salt cleartextPassword })) |> ignore
 
-let blankUserRecord : Dto.UserDetails = {
-    username = ""
+let blankUserRecord username : Dto.UserDetails = {
+    username = username
     firstName = ""
     lastName = ""
     email = None
     language = "" }
 
-let blankProjectRecord : Dto.ProjectDetails = {
-    code = ""
+let blankProjectRecord projectCode : Dto.ProjectDetails = {
+    code = projectCode
     name = ""
     description = ""
-    membership = None }
+    membership = Dictionary<string,string>() }
 
 (* Not needed now that the API design is username/projectCode-centric
 let counter init =
@@ -58,8 +58,7 @@ let membershipIdCounter = counter 0
 let memberRoleIdCounter = counter 0
 *)
 
-// TODO: Move this list to the unit test setup
-let roles = Dto.standardRoles
+let roles = SampleData.StandardRoles
 
 type KeyReplacementError =
     | TargetKeyAlreadyExists
@@ -82,20 +81,20 @@ let projectCodeReplacementLock = obj()
 let replaceUsername oldUsername newUsername =
     let mutable replacements = []
     let replaceUsernameInList lst = lst |> List.map (fun ((name, role) as pair) -> if name = oldUsername then (newUsername, role) else pair)
-    let mkNewMembers (oldMembers : Dto.MemberList) : Dto.MemberList =
-        oldMembers |> replaceUsernameInList
+    let mkNewMembers (oldMembers : IDictionary<string,string>) : IDictionary<string,string> =
+        match oldMembers.TryGetValue oldUsername with
+        | false, _ -> oldMembers
+        | true, role ->
+            let newMembers = Dictionary<string,string>(oldMembers)
+            newMembers.Remove oldUsername |> ignore
+            newMembers.[newUsername] <- role
+            newMembers :> IDictionary<string,string>
     let mkNewProject _projectCode (oldProject : Dto.ProjectDetails) =
-        match oldProject.membership with
-        | None -> oldProject
-        | Some members ->
-            { oldProject with membership = Some (mkNewMembers members) }
+        { oldProject with membership = mkNewMembers oldProject.membership }
     for item in projectStorage do
         let projectCode, project = item.Key, item.Value
-        match project.membership with
-        | None -> ()
-        | Some members ->
-            if members |> List.exists (fst >> ((=) oldUsername)) then
-                replacements <- (projectCode, project) :: replacements
+        if project.membership.ContainsKey oldUsername then
+            replacements <- (projectCode, project) :: replacements
     // Check for overlapping username as late as possible; this won't eliminate race conditions, but it will minimize them as much as we can
     if not <| isValidUsername newUsername then
         Error InvalidTargetKey

--- a/src/Server/MemoryStorage.fs
+++ b/src/Server/MemoryStorage.fs
@@ -41,7 +41,7 @@ let blankProjectRecord projectCode : Dto.ProjectDetails = {
     code = projectCode
     name = ""
     description = ""
-    membership = Dictionary<string,string>() }
+    membership = Map.empty }
 
 (* Not needed now that the API design is username/projectCode-centric
 let counter init =
@@ -81,14 +81,10 @@ let projectCodeReplacementLock = obj()
 let replaceUsername oldUsername newUsername =
     let mutable replacements = []
     let replaceUsernameInList lst = lst |> List.map (fun ((name, role) as pair) -> if name = oldUsername then (newUsername, role) else pair)
-    let mkNewMembers (oldMembers : IDictionary<string,string>) : IDictionary<string,string> =
-        match oldMembers.TryGetValue oldUsername with
-        | false, _ -> oldMembers
-        | true, role ->
-            let newMembers = Dictionary<string,string>(oldMembers)
-            newMembers.Remove oldUsername |> ignore
-            newMembers.[newUsername] <- role
-            newMembers :> IDictionary<string,string>
+    let mkNewMembers (oldMembers : Map<string,string>) : Map<string,string> =
+        match oldMembers |> Map.tryFind oldUsername with
+        | None -> oldMembers
+        | Some role -> oldMembers |> Map.remove oldUsername |> Map.add newUsername role
     let mkNewProject _projectCode (oldProject : Dto.ProjectDetails) =
         { oldProject with membership = mkNewMembers oldProject.membership }
     for item in projectStorage do

--- a/src/Server/Model.fs
+++ b/src/Server/Model.fs
@@ -90,27 +90,9 @@ type RemoveMembership = RemoveMembership of (string -> string -> string -> RoleT
 type RemoveUserFromAllRolesInProject = RemoveUserFromAllRolesInProject of (string -> string -> string -> Async<bool>)
 type ArchiveProject = string -> string -> Async<bool>
 
-let usersQueryAsync (connString : string) (limit : int option) (offset : int option) =
-    async {
-        let ctx = sql.GetDataContext connString
-        let usersQuery = query {
-            for user in ctx.Languagedepot.Users do
-            join mail in !! ctx.Languagedepot.EmailAddresses on (user.Id = mail.UserId)
-            select (user.Login, user.Firstname, user.Lastname, user.Language, (if isNull mail then None else Some mail.Address))
-        }
-        let! users =
-            match limit, offset with
-            | None, None -> usersQuery |> List.executeQueryAsync
-            | None, Some offset -> query { for user in usersQuery do skip offset } |> List.executeQueryAsync
-            | Some limit, None -> query { for user in usersQuery do take limit } |> List.executeQueryAsync
-            | Some limit, Some offset -> query { for user in usersQuery do skip offset; take limit } |> List.executeQueryAsync
-        let usersAndEmails = users |> List.map Dto.UserDetails.FromSql
-        return usersAndEmails
-    }
-
 open FSharp.Control.Tasks.V2
 
-let fetchData (convertRow : MySqlDataReader -> 'result) (reader : MySqlDataReader) = task {
+let getSqlResult (convertRow : MySqlDataReader -> 'result) (reader : MySqlDataReader) = task {
     if not reader.HasRows then
         return Array.empty
     else
@@ -126,100 +108,148 @@ let fetchData (convertRow : MySqlDataReader -> 'result) (reader : MySqlDataReade
         return result.ToArray()
 }
 
+let fetchDataWithParams (connString : string) (sql : string) (setParams : MySqlCommand -> unit) (convertRow : MySqlDataReader -> 'result) = task {
+    use conn = new MySqlConnection(connString)
+    do! conn.OpenAsync()
+    use cmd = new MySqlCommand(sql, conn)
+    setParams cmd
+    use! reader = cmd.ExecuteReaderAsync()
+    let! result = reader :?> MySqlDataReader |> getSqlResult convertRow
+    return result
+}
+
+let fetchData (connString : string) (sql : string) (convertRow : MySqlDataReader -> 'result) =
+    fetchDataWithParams connString sql ignore convertRow
+
+let doScalarQueryWithParams<'result> (connString : string) (sql : string) (setParams : MySqlCommand -> unit) = task {
+    use conn = new MySqlConnection(connString)
+    do! conn.OpenAsync()
+    use cmd = new MySqlCommand(sql, conn)
+    setParams cmd
+    let! boxedResult = cmd.ExecuteScalarAsync()
+    return (unbox<'result> boxedResult)
+}
+
+let doScalarQuery<'result> connString sql =
+    doScalarQueryWithParams<'result> connString sql ignore
+
+let doCountQueryWithParams connString sql setParams = doScalarQueryWithParams<int> connString sql setParams
+let doCountQuery connString sql = doCountQueryWithParams connString sql ignore
+
+let doNonQueryWithParams (connString : string) (sql : string) (setParams : MySqlCommand -> unit) = task {
+    use conn = new MySqlConnection(connString)
+    do! conn.OpenAsync()
+    use cmd = new MySqlCommand(sql, conn)
+    setParams cmd
+    let! result = cmd.ExecuteNonQueryAsync()
+    try
+        let count = unbox<int> result
+        return count
+    with _ ->
+        return 0
+}
+
+let doNonQuery (connString : string) (sql : string) =
+    doNonQueryWithParams connString sql ignore
+
+let convertUserRow (reader : MySqlDataReader) =
+    {
+        Dto.UserDetails.username = reader.GetString(0)
+        Dto.UserDetails.firstName = reader.GetString(1)
+        Dto.UserDetails.lastName = reader.GetString(2)
+        Dto.UserDetails.language = if reader.IsDBNull(3) then "en" else reader.GetString(3)
+        Dto.UserDetails.email = if reader.IsDBNull(4) then None else Some (reader.GetString(4))
+    }
+
+let baseUsersQuery = "SELECT login, firstname, lastname, language, address FROM users LEFT JOIN email_addresses ON users.id = email_addresses.user_id"
+
 let manualUsersQuery (connString : string) (limit : int option) (offset : int option) =
     async {
-        use conn = new MySqlConnection(connString)
-        do! conn.OpenAsync() |> Async.AwaitTask
-        use cmd = new MySqlCommand("SELECT login, firstname, lastname, language, address FROM users LEFT JOIN email_addresses ON users.id = email_addresses.user_id", conn)
-        use! reader = cmd.ExecuteReaderAsync() |> Async.AwaitTask
-        let! result =
-            reader :?> MySqlDataReader
-            |> fetchData (fun reader ->
-            {
-                Dto.UserDetails.username = reader.GetString(0)
-                Dto.UserDetails.firstName = reader.GetString(1)
-                Dto.UserDetails.lastName = reader.GetString(2)
-                Dto.UserDetails.language = if reader.IsDBNull(3) then "en" else reader.GetString(3)
-                Dto.UserDetails.email = if reader.IsDBNull(4) then None else Some (reader.GetString(4))
-            })
-            |> Async.AwaitTask
+        let sql = baseUsersQuery
+        let! result = fetchData connString sql convertUserRow |> Async.AwaitTask
         return result |> List.ofArray
+    }
+
+let getUser (connString : string) username =
+    async {
+        let sql = baseUsersQuery + " WHERE login = @username"
+        let setParams (cmd : MySqlCommand) =
+            cmd.Parameters.AddWithValue("username", username) |> ignore
+        let! result = fetchDataWithParams connString sql setParams convertUserRow |> Async.AwaitTask
+        return result |> Array.tryHead
     }
 
 let searchUsersLoose (connString : string) (searchTerm : string) =
     async {
-        let ctx = sql.GetDataContext(connString, SelectOperations.DatabaseSide)
-        let! users =
-            query {
-                for user in ctx.Languagedepot.Users do
-                join mail in !! ctx.Languagedepot.EmailAddresses on (user.Id = mail.UserId)
-                where (user.Login.Contains searchTerm ||
-                       user.Firstname.Contains searchTerm ||
-                       user.Lastname.Contains searchTerm ||
-                       mail.Address.Contains searchTerm)
-                select (user.Login, user.Firstname, user.Lastname, user.Language, (if isNull mail then None else Some mail.Address))
-            } |> List.executeQueryAsync
-        return users |> List.map Dto.UserDetails.FromSql
+        let sql = baseUsersQuery + " WHERE login LIKE @searchTerm OR firstname LIKE @searchTerm OR lastname LIKE @searchTerm OR address LIKE @searchTerm"
+        let escapedSearchTerm = "%" + searchTerm.Replace(@"\", @"\\").Replace("%", @"\%") + "%"
+        // TODO: Test whether that works, or whether we need to write something like "LIKE %@searchTerm%" instead
+        let setParams (cmd : MySqlCommand) =
+            cmd.Parameters.AddWithValue("searchTerm", escapedSearchTerm) |> ignore
+        let! result = fetchDataWithParams connString sql setParams convertUserRow |> Async.AwaitTask
+        return result |> List.ofArray
     }
 
 let searchUsersExact (connString : string) (searchTerm : string) =
     async {
-        let ctx = sql.GetDataContext connString
-        let! users =
-            query {
-                for user in ctx.Languagedepot.Users do
-                join mail in !! ctx.Languagedepot.EmailAddresses on (user.Id = mail.UserId)
-                where (user.Login = searchTerm ||
-                       user.Firstname = searchTerm ||
-                       user.Lastname = searchTerm ||
-                       mail.Address = searchTerm)
-                select (user.Login, user.Firstname, user.Lastname, user.Language, (if isNull mail then None else Some mail.Address))
-            } |> List.executeQueryAsync
-        return users |> List.map Dto.UserDetails.FromSql
+        let sql = baseUsersQuery + " WHERE login = @searchTerm OR firstname = @searchTerm OR lastname = @searchTerm OR address = @searchTerm"
+        let! result = fetchDataWithParams connString sql (fun cmd -> cmd.Parameters.AddWithValue("searchTerm", searchTerm) |> ignore) convertUserRow |> Async.AwaitTask
+        return result |> List.ofArray
     }
+
+let toDict (s : string) =
+    Newtonsoft.Json.JsonConvert.DeserializeObject<System.Collections.Generic.Dictionary<string,string>>(s)
+
+let convertProjectRow (reader : MySqlDataReader) = {
+        Dto.ProjectDetailsInternal.code = reader.GetString("identifier")
+        Dto.ProjectDetailsInternal.name = reader.GetString("name")
+        Dto.ProjectDetailsInternal.description = reader.GetString("description")
+        Dto.ProjectDetailsInternal.membership = reader.GetString("user_roles") |> toDict  // TODO: Handle case where we don't want the complete membership list
+    }
+
+let baseProjectQuery = "SELECT identifier, name, description, \"{}\" FROM projects"
+
+// TODO: Either we set a global MySQL setting, or we run the following before our projects query. Choosing the global setting for now since it's simpler.
+// let projectsPreQuery = "SET SESSION sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"
+
+let projectWithMembersBaseQuery =
+    "SELECT projects.identifier, projects.name, projects.description, json_objectagg(users.login, roles.name) AS user_roles" +
+    " FROM projects" +
+    " LEFT JOIN members ON members.project_id = projects.id" +
+    " JOIN member_roles ON member_roles.member_id = members.id" +
+    " JOIN roles ON roles.id = member_roles.role_id" +
+    " JOIN users on members.user_id = users.id"
+// MySQL wants WHERE clause before GROUP BY clause, so we add GROUP BY as a separate step
+let projectsWithMembersGroupByClause = " GROUP BY projects.identifier"
 
 let projectsQueryAsync (connString : string) =
     async {
-        let ctx = sql.GetDataContext connString
-        let projectsQuery = query {
-            for project in ctx.Languagedepot.Projects do
-            where (project.Status = ProjectStatus.Active)
-            select (Dto.ProjectDetails.FromSql project)
-        }
-        return! projectsQuery |> List.executeQueryAsync
+        let sql = baseProjectQuery
+        let setParams (cmd : MySqlCommand) =
+            ()
+        let! result = fetchDataWithParams connString sql setParams convertProjectRow |> Async.AwaitTask
+        return result |> List.ofArray
     }
 
 let projectsAndRolesQueryAsync (connString : string) =
     async {
-        let ctx = sql.GetDataContext connString
-        let projectsQuery = query {
-            for project in ctx.Languagedepot.Projects do
-            where (project.Status = ProjectStatus.Active)
-            join membership in !! ctx.Languagedepot.Members on (project.Id = membership.ProjectId)
-            join memberRole in !! ctx.Languagedepot.MemberRoles on (membership.Id = memberRole.MemberId)
-            join user in !! ctx.Languagedepot.Users on (membership.UserId = user.Id)
-            join role in !! ctx.Languagedepot.Roles on (memberRole.RoleId = role.Id)
-            select (project, user.Login, role.Id, role.Name)
-        }
-        let! projectsAndRoles = projectsQuery |> List.executeQueryAsync
-        return projectsAndRoles |> List.groupBy (fun (project, _, _, _) -> project.Identifier) |> List.choose (snd >> Dto.ProjectDetails.FromSqlWithRoles)
+        let sql = projectWithMembersBaseQuery + projectsWithMembersGroupByClause
+        let! result = fetchData connString sql convertProjectRow |> Async.AwaitTask
+        return result |> List.ofArray
     }
 
 let projectsCountAsync (connString : string) =
     async {
-        let ctx = sql.GetDataContext connString
-        return query {
-            for project in ctx.Languagedepot.Projects do
-            where (project.Status = ProjectStatus.Active)
-            count
-        }
+        let sql = "SELECT COUNT(*) FROM projects"
+        return! doCountQuery connString sql |> Async.AwaitTask
     }
 
 let realProjectsCountAsync (connString : string) =
     async {
-        let! projects = projectsQueryAsync connString
+        let sql = baseProjectQuery
+        let! result = fetchData connString sql convertProjectRow |> Async.AwaitTask
         return
-            projects
+            result
             |> Seq.map (fun project -> project, GuessProjectType.guessType project.code project.name project.description)
             |> Seq.filter (fun (project, projectType) -> projectType <> Test && not (project.code.StartsWith "test"))
             |> Seq.length
@@ -227,223 +257,251 @@ let realProjectsCountAsync (connString : string) =
 
 let usersCountAsync (connString : string) =
     async {
-        let ctx = sql.GetDataContext connString
-        return query {
-            for _ in ctx.Languagedepot.Users do
-            count
-        }
+        let sql = "SELECT COUNT(*) FROM users"
+        return! doCountQuery connString sql |> Async.AwaitTask
     }
+
+// TODO: Implement userExists, then use it later on below in upsertUser
 
 let userExists (connString : string) username =
     async {
-        let ctx = sql.GetDataContext connString
-        return query {
-            for user in ctx.Languagedepot.Users do
-            select user.Login
-            contains username }
+        let sql = "SELECT COUNT(*) FROM users WHERE login = @username"
+        let setParams (cmd : MySqlCommand) =
+            cmd.Parameters.AddWithValue("username", username) |> ignore
+        let! count = doCountQueryWithParams connString sql setParams |> Async.AwaitTask
+        return (count > 0)
     }
 
 let projectExists (connString : string) projectCode =
     async {
-        let ctx = sql.GetDataContext connString
-        return query {
-            for project in ctx.Languagedepot.Projects do
-            // We do NOT check where (project.Status = ProjectStatus.Active) here because we want to forbid re-using project codes even of inactive projects
-            where (project.Identifier.IsSome)
-            select project.Identifier.Value
-            contains projectCode }
+        let sql = "SELECT COUNT(*) FROM projects WHERE identifier = @projectCode"
+        let setParams (cmd : MySqlCommand) =
+            cmd.Parameters.AddWithValue("projectCode", projectCode) |> ignore
+        let! count = doCountQueryWithParams connString sql setParams |> Async.AwaitTask
+        return (count > 0)
     }
 
 let isAdmin (connString : string) username =
     async {
-        let ctx = sql.GetDataContext connString
-        return query {
-            for user in ctx.Languagedepot.Users do
-            where (user.Login = username)
-            select (user.Admin <> 0y)
-            headOrDefault }
-    }
-
-let getUser (connString : string) username =
-    async {
-        let ctx = sql.GetDataContext connString
-        let userAndEmails =
-            query {
-                for user in ctx.Languagedepot.Users do
-                where (user.Login = username)
-                join mail in !! ctx.Languagedepot.EmailAddresses on (user.Id = mail.UserId)
-                select (Some (user.Login, user.Firstname, user.Lastname, user.Language, (if isNull mail then None else Some mail.Address)))
-                headOrDefault
-            }
-        return userAndEmails |> Option.map Dto.UserDetails.FromSql
+        let sql = "SELECT is_admin FROM users WHERE login = @username"
+        let setParams (cmd : MySqlCommand) =
+            cmd.Parameters.AddWithValue("username", username) |> ignore
+        let convertRow (reader : MySqlDataReader) = reader.GetBoolean(0)
+        let! results = fetchDataWithParams connString sql setParams convertRow |> Async.AwaitTask
+        if results.Length > 0 then return results.[0] else return false
     }
 
 let getProject (connString : string) projectCode =
     async {
-        let ctx = sql.GetDataContext connString
-        return query {
-            for project in ctx.Languagedepot.Projects do
-            where (not project.Identifier.IsNone)
-            where (project.Identifier.Value = projectCode)
-            select (Some (Dto.ProjectDetails.FromSql project))
-            exactlyOneOrDefault }
+        let sql = baseProjectQuery + " WHERE projects.identifier = @projectCode"
+        let setParams (cmd : MySqlCommand) =
+            cmd.Parameters.AddWithValue("projectCode", projectCode) |> ignore
+        let! result = fetchDataWithParams connString sql setParams convertProjectRow |> Async.AwaitTask
+        return result |> List.ofArray
     }
 
 let getProjectWithRoles (connString : string) projectCode =
     async {
-        let ctx = sql.GetDataContext connString
-        let projectQuery = query {
-            for project in ctx.Languagedepot.Projects do
-            join membership in !! ctx.Languagedepot.Members on (project.Id = membership.ProjectId)
-            join memberRole in !! ctx.Languagedepot.MemberRoles on (membership.Id = memberRole.MemberId)
-            join user in !! ctx.Languagedepot.Users on (membership.UserId = user.Id)
-            join role in !! ctx.Languagedepot.Roles on (memberRole.RoleId = role.Id)
-            where (project.Identifier.IsSome && project.Identifier.Value = projectCode)
-            select (project, user.Login, role.Id, role.Name)
-        }
-        let! projectAndRoles = projectQuery |> List.executeQueryAsync
-        return  Dto.ProjectDetails.FromSqlWithRoles projectAndRoles
+        let whereClause = " WHERE projects.identifier = @projectCode"
+        let sql = projectWithMembersBaseQuery + whereClause + projectsWithMembersGroupByClause
+        let setParams (cmd : MySqlCommand) =
+            cmd.Parameters.AddWithValue("projectCode", projectCode) |> ignore
+        let! result = fetchDataWithParams connString sql setParams convertProjectRow |> Async.AwaitTask
+        return result |> List.ofArray
     }
 
 let createProject (connString : string) (project : Api.CreateProject) =
     async {
-        // TODO: Handle case where project already exists, and reject if it does. Also, API shape needs to become Async<int option> instead of Async<int>
-        let ctx = sql.GetDataContext connString
-        let sqlProject = ctx.Languagedepot.Projects.Create()
-        // sqlProject.Id <- project.Id // int
-        sqlProject.Name <- project.name // string
-        sqlProject.Description <- project.description // string option // Long
-        // sqlProject.Homepage <- project.Homepage // string option // Long
-        // sqlProject.IsPublic <- if project.IsPublic then 1y else 0y
-        // sqlProject.ParentId <- project.ParentId // int option
-        let now = DateTime.UtcNow  // TODO: Pass in the "now" value to use, so unit tests can be more deterministic
-        sqlProject.CreatedOn <- Some now
-        sqlProject.UpdatedOn <- Some now
-        sqlProject.Identifier <- Some project.code // string option // 20 chars
-        sqlProject.Status <- ProjectStatus.Active
-        do! ctx.SubmitUpdatesAsync()
-        return sqlProject.Id
+        let sqlTxt = "INSERT INTO projects (name, description, identifier, status, created_on, updated_on) VALUES (@name, @description, @identifier, @status, NOW(), NOW())"
+        use conn = new MySqlConnection(connString)
+        do! conn.OpenAsync() |> Async.AwaitTask
+        use cmd = new MySqlCommand(sqlTxt, conn)
+        cmd.Parameters.AddWithValue("name", project.name) |> ignore
+        cmd.Parameters.AddWithValue("description", project.description) |> ignore
+        cmd.Parameters.AddWithValue("identifier", project.code) |> ignore
+        cmd.Parameters.AddWithValue("status", ProjectStatus.Active) |> ignore
+        let! result = cmd.ExecuteNonQueryAsync() |> Async.AwaitTask
+        if result = 0 then return -1
+        elif result < 0 then return result
+        else
+            let newId = int cmd.LastInsertedId
+            return newId
     }
 
-let createUserImpl (connString : string) (user : Api.CreateUser) =
+let createUserImpl (connString : string) (user : Api.CreateUser) (sql : string) =
+    // TODO: Just make everything here a task{} instead of async{}; it'll be simpler
     async {
-        let ctx = sql.GetDataContext connString
+        // TODO: Password creation belongs in the controller, not the model. This requires a new CreateUserInternal data type which will carry the hashed password and the salt
         let salt = PasswordHashing.createSalt (Guid.NewGuid())
         let hashedPassword = PasswordHashing.hashPassword salt user.password
-
-        let sqlUser = ctx.Languagedepot.Users.Create()
-        sqlUser.Firstname <- user.firstName
-        sqlUser.Lastname <- user.lastName
-        sqlUser.HashedPassword <- hashedPassword
-        sqlUser.Login <- user.username
-        do! ctx.SubmitUpdatesAsync()  // This populates sqlUser.Id, which we'll need when we create email address records
-
-        let now = DateTime.UtcNow
-        match user.emailAddresses with
-        | None -> ()
-        | Some email ->
-            let sqlMail = ctx.Languagedepot.EmailAddresses.Create()
-            sqlMail.UserId <- sqlUser.Id
-            sqlMail.Address <- email
-            sqlMail.IsDefault <- 1y
-            sqlMail.Notify <- 0y
-            sqlMail.CreatedOn <- now
-            sqlMail.UpdatedOn <- now
-            do! ctx.SubmitUpdatesAsync()
-        return sqlUser.Id
+        use conn = new MySqlConnection(connString)
+        do! conn.OpenAsync() |> Async.AwaitTask
+        use transaction = conn.BeginTransaction()
+        use cmd = new MySqlCommand(sql, conn, transaction)
+        cmd.Parameters.AddWithValue("login", user.username) |> ignore
+        cmd.Parameters.AddWithValue("firstname", user.firstName) |> ignore
+        cmd.Parameters.AddWithValue("lastname", user.lastName) |> ignore
+        cmd.Parameters.AddWithValue("hashedPassword", hashedPassword) |> ignore
+        cmd.Parameters.AddWithValue("salt", salt) |> ignore
+        cmd.Parameters.AddWithValue("status", UserStatus.Active) |> ignore
+        let! result = cmd.ExecuteNonQueryAsync() |> Async.AwaitTask
+        if result < 1 then
+            do! transaction.RollbackAsync() |> Async.AwaitTask
+            return (if result = 0 then -1 else result)
+        else
+            let didUpsert = result > 1
+            // Inserted user, so insert email addresses as well
+            let newUserId = int cmd.LastInsertedId
+            match user.emailAddresses with
+            | None -> return newUserId
+            | Some email ->
+                let sql = "INSERT INTO email_addresses (user_id, address, is_default, created_on, updated_on) " +
+                          "VALUES (@userId, @email, 1, NOW(), NOW())"
+                if didUpsert then ()  // TODO: Nope. INSERT ON DUPLICATE KEY UPDATE isn't going to work here because Redmine doesn't have a UNIQUE constraint on email addresses...!
+                use cmd = new MySqlCommand(sql, conn)
+                cmd.Parameters.AddWithValue("user_id", newUserId) |> ignore
+                cmd.Parameters.AddWithValue("address", email) |> ignore
+                let! result = cmd.ExecuteNonQueryAsync() |> Async.AwaitTask
+                if result < 1 then
+                    do! transaction.RollbackAsync() |> Async.AwaitTask
+                    return (if result = 0 then -1 else result)
+                else
+                    do! transaction.CommitAsync() |> Async.AwaitTask
+                    return newUserId
     }
 
-let createUser (connString : string) (user : Api.CreateUser) = createUserImpl connString user
+let createUser (connString : string) (user : Api.CreateUser) =
+    let sql = "INSERT INTO users (login, firstname, lastname, hashed_password, salt, status, created_on, updated_on) " +
+              "VALUES (@login, @firstname, @lastname, @hashedPassword, @salt, @status, NOW(), NOW())"
+    createUserImpl connString user sql
+
+let updateUser (connString : string) (login : string) (updatedUser : Api.CreateUser) =
+    async {
+        // Everyone may change their own data, but only admins may change some else's data
+        let sql = "SELECT is_admin, login FROM users WHERE login = @login"
+        let setParams (cmd : MySqlCommand) =
+            cmd.Parameters.AddWithValue("login", updatedUser.login.username) |> ignore
+            // TODO: Once we move "is this allowed?" logic into controller, verify password as well
+        let! result = fetchDataWithParams connString sql setParams (fun row -> row.GetBoolean("is_admin"), row.GetString("login")) |> Async.AwaitTask
+        if result.Length = 0 then
+            // TODO: Edit to return a Result<unit, errorDU> so we can indicate why this may fail (e.g., "Invalid login" or whatever). In this case, login user not found
+            // That errorDU should live in ErrorCodes.fs
+            return ()
+        let isAdmin, loggedInUser = result.[0]
+        // TODO: Move "is this allowed?" logic into the controller, not here
+        // TODO: Once we move "is this allowed?" logic into controller, verify password as well
+        let allowed = isAdmin || loggedInUser = updatedUser.username
+        if not allowed then
+            // Return error indicating 403 forbidden
+            return 0
+        else
+            let! salt =
+                let sql = "SELECT salt FROM users where login = @username"
+                let setParams (cmd : MySqlCommand) =
+                    cmd.Parameters.AddWithValue("username", updatedUser.username) |> ignore
+                doScalarQueryWithParams connString sql setParams |> Async.AwaitTask
+            let isPasswordChange = not (String.IsNullOrEmpty updatedUser.password)
+            let hashedPassword = if isPasswordChange then PasswordHashing.hashPassword salt updatedUser.password else ""
+            let sql =
+                if isPasswordChange then
+                    "UPDATE users SET login = @username, hashed_password = @hashedPassword, must_change_passwd = @mustChangePassword, firstname = @firstName, lastname = @lastName, language = @language" +
+                    " WHERE login = @loggedInUser"
+                else
+                    "UPDATE users SET login = @username, must_change_passwd = @mustChangePassword, firstname = @firstName, lastname = @lastName, language = @language" +
+                    " WHERE login = @loggedInUser"
+            let setParams (cmd : MySqlCommand) =
+                cmd.Parameters.AddWithValue("login", updatedUser.username) |> ignore
+                if isPasswordChange then
+                    cmd.Parameters.AddWithValue("hashedPassword", hashedPassword) |> ignore
+                cmd.Parameters.AddWithValue("mustChangePassword", updatedUser.mustChangePassword) |> ignore
+                cmd.Parameters.AddWithValue("firstName", updatedUser.firstName) |> ignore
+                cmd.Parameters.AddWithValue("lastName", updatedUser.lastName) |> ignore
+                cmd.Parameters.AddWithValue("language", updatedUser.language |> Option.defaultValue "en") |> ignore
+                cmd.Parameters.AddWithValue("loggedInUser", loggedInUser) |> ignore
+            let! changedRows = doNonQueryWithParams connString sql setParams |> Async.AwaitTask
+            // TODO: Detect changeRows being 0 and return an error code
+            return changedRows
+    }
 
 let upsertUser (connString : string) (login : string) (updatedUser : Api.CreateUser) =
     async {
-        let ctx = sql.GetDataContext connString
-        let maybeUser = query {
-            for user in ctx.Languagedepot.Users do
-                where (user.Login = login)
-                select (Some user)
-                exactlyOneOrDefault
-        }
-        match maybeUser with
-        | None ->
-            return! createUserImpl connString updatedUser
-        | Some sqlUser ->
-            sqlUser.Login <- updatedUser.username
-            sqlUser.Firstname <- updatedUser.firstName
-            sqlUser.Lastname <- updatedUser.lastName
-            // Password should be changed with changePassword API, so we don't update the password here
-            // TODO: Deal with email addresses changing -- API doesn't allow it now, but it should
-            sqlUser.Language <- updatedUser.language
-            sqlUser.UpdatedOn <- Some DateTime.UtcNow  // TODO: Pass in "now" value to use, so unit tests can be deterministic
-            sqlUser.MustChangePasswd <- if updatedUser.mustChangePassword then 1y else 0y
-            do! ctx.SubmitUpdatesAsync()
-            return sqlUser.Id
+        let! shouldUpdate = userExists connString updatedUser.username
+        if not shouldUpdate then
+            return! createUser connString updatedUser
+        else
+            return! updateUser connString login updatedUser
+    }
+    // This won't work, because the Redmine data model doesn't have "login" as a unique key constraint (?!?)
+    // let xql = "INSERT INTO users (login, firstname, lastname, hashed_password, salt, status, created_on, updated_on) " +
+    //           "VALUES (@login, @firstname, @lastname, @hashedPassword, @salt, @status, NOW(), NOW()) " +
+    //           "ON DUPLICATE KEY UPDATE firstname = @firstname, lastname = @lastname, hashedPassword = @hashedPassword, salt = @salt, status = @status, updated_on = NOW()"
+    // createUserImpl connString updatedUser xql
+
+// TODO: Do manual SQL statements from here on down (we've done up to here so far)
+
+let projectsAndRolesQueryAsyncReminder (connString : string) =
+    async {
+        let sql = projectWithMembersBaseQuery + projectsWithMembersGroupByClause
+        let! result = fetchData connString sql convertProjectRow |> Async.AwaitTask
+        return result |> List.ofArray
     }
 
-let changePassword (connString : string) (login : string) (changeRequest : Api.ChangePassword) =
-    async {
-        let ctx = sql.GetDataContext connString
-        let maybeUser = query {
-            for user in ctx.Languagedepot.Users do
-                where (user.Login = login)
-                select (Some user)
-                exactlyOneOrDefault
-        }
-        match maybeUser with
-        | None -> return false
-        | Some sqlUser ->
-            let allowed = sqlUser.Admin <> 0y || sqlUser.Login = changeRequest.username
-            // TODO: This puts business logic (admins can change passwords) into the model, and it really belongs in the controller. Fix this.
-            if allowed then
-                sqlUser.HashedPassword <- PasswordHashing.hashPassword (sqlUser.Salt |> Option.defaultValue "") changeRequest.password
-                do! ctx.SubmitUpdatesAsync()
-                return true
-            else
-                return false
-    }
+let projectsAndRolesBaseQuery =
+    "SELECT projects.identifier AS identifier, roles.name AS role" +
+    " FROM members" +
+    " JOIN projects ON members.project_id = projects.id" +
+    " JOIN member_roles ON member_roles.member_id = members.id" +
+    " JOIN roles ON roles.id = member_roles.role_id" +
+    " JOIN users on members.user_id = users.id"
+let projectsAndRolesGroupByClause = " GROUP BY users.login"
+
+let projectsAndRolesByUserImpl (connString : string) username = async {
+    let whereClause = " WHERE users.login = @username"
+    let xql = projectsAndRolesBaseQuery + whereClause + projectsAndRolesGroupByClause
+    let setParams (cmd : MySqlCommand) =
+            cmd.Parameters.AddWithValue("username", username) |> ignore
+    let convertRow (reader : MySqlDataReader) =
+        reader.GetString("identifier"), reader.GetString("role")
+    let! result = fetchDataWithParams connString xql setParams convertRow |> Async.AwaitTask
+    return result |> List.ofArray
+}
+// TODO: Figure out how to "pass through" the result from json_objectagg
+
+let getProjectDetails (conn : MySqlConnection) (projectCode : string) = async {
+    let sql = baseProjectQuery + "WHERE identifier = @projectCode"
+    use cmd = new MySqlCommand(sql, conn)
+    cmd.Parameters.AddWithValue("projectCode", projectCode) |> ignore
+    use! reader = cmd.ExecuteReaderAsync() |> Async.AwaitTask
+    let! result = reader :?> MySqlDataReader |> getSqlResult convertProjectRow |> Async.AwaitTask
+    return result
+}
 
 let projectsAndRolesByUser (connString : string) username = async {
-    let ctx = sql.GetDataContext connString
-    let projectsQuery = query {
-        for user in ctx.Languagedepot.Users do
-        where (user.Login = username)
-        join membership in ctx.Languagedepot.Members
-            on (user.Id = membership.UserId)
-        join project in ctx.Languagedepot.Projects
-            on (membership.ProjectId = project.Id)
-        where (project.Status = ProjectStatus.Active)
-        join memberRole in ctx.Languagedepot.MemberRoles
-            on (membership.Id = memberRole.MemberId)
-
-        select (Dto.ProjectDetails.FromSql project, RoleType.OfNumericId memberRole.RoleId)
-    }
-    let! projectsAndRoles = projectsQuery |> List.executeQueryAsync
-    return projectsAndRoles |> List.groupBy fst |> List.map (fun (proj, projAndRoles) -> (proj, List.map snd projAndRoles))
+    let! projectsAndRoles = projectsAndRolesByUserImpl connString username
+    return projectsAndRoles
 }
 
-let projectsAndRolesByUserRole connString username (roleType : RoleType) = async {
-    let! projectsAndRoles = projectsAndRolesByUser connString username
-    return projectsAndRoles |> List.filter (fun (proj, roles) -> roles |> List.contains roleType)
+let projectsAndRolesByUserRole connString username (roleName : string) = async {
+    let! projectsAndRoles = projectsAndRolesByUserImpl connString username
+    return projectsAndRoles |> List.filter (fun (proj, role) -> role = roleName)
 }
 
-let projectsByUserRole connString username (roleType : RoleType) = async {
-    let! projectsAndRoles = projectsAndRolesByUser connString username
-    return projectsAndRoles |> List.filter (fun (proj, roles) -> roles |> List.contains roleType) |> List.map fst
+let projectsByUserRole connString username (roleName : string) = async {
+    let! projectsAndRoles = projectsAndRolesByUserImpl connString username
+    return projectsAndRoles |> List.filter (fun (proj, role) -> role = roleName) |> List.map fst
 }
 
 let projectsByUser connString username = async {
-    let! projectsAndRoles = projectsAndRolesByUser connString username
+    let! projectsAndRoles = projectsAndRolesByUserImpl connString username
     return projectsAndRoles |> List.map fst
 }
 
 let roleNames (connString : string) =
     async {
-        let ctx = sql.GetDataContext connString
-        let roleQuery = query {
-            for role in ctx.Languagedepot.Roles do
-                select (Dto.RoleDetails.FromSql role)
-        }
-        return! roleQuery |> List.executeQueryAsync
+        let sql = "SELECT id, name FROM roles"
+        let convertRow (reader : MySqlDataReader) =
+            reader.GetInt32("id"), reader.GetString("name")
+        return! fetchData connString sql convertRow |> Async.AwaitTask
     }
 
 let verifyPass (clearPass : string) (salt : string) (hashPass : string) =
@@ -454,158 +512,154 @@ let verifyLoginInfo (connString : string) (loginCredentials : Api.LoginCredentia
     // During development of the client UI, just accept any credentials. TODO: Natually, restore real code before going to production
     async { return true }
     // async {
-    //     let ctx = sql.GetDataContext connString
-    //     let! user = query { for user in ctx.Languagedepot.Users do
-    //                             where (user.Login = loginCredentials.username)
-    //                             select user } |> Seq.tryHeadAsync
-    //     match user with
-    //     | None -> return false
-    //     | Some user -> return verifyPass loginCredentials.password (user.Salt |> Option.defaultValue "") user.HashedPassword
+    //     let sql = "SELECT salt, hashed_password FROM users where login = @username"
+    //     let setParams (cmd : MySqlCommand) =
+    //         cmd.Parameters.AddWithValue("username", loginCredentials.username) |> ignore
+    //     let convertRow (reader : MySqlDataReader) =
+    //         reader.GetString("salt"), reader.GetString("hashed_password")
+    //     let rows = fetchDataWithParams connString sql setParams convertRow |> Async.AwaitTask
+    //     if rows.Length > 0 then
+    //         let salt, hashedPassword = rows.[0]
+    //         return verifyPass loginCredentials.password salt hashedPassword
+    //     else
+    //         return false
     // }
 
-let addMembershipById (connString : string) (userId : int) (projectId : int) (roleId : int) =
+let changePassword (connString : string) (login : string) (changeRequest : Api.ChangePassword) =
     async {
-        let ctx = sql.GetDataContext connString
-        let membershipQuery = query {
-            for membership in ctx.Languagedepot.Members do
-                where (membership.ProjectId = projectId && membership.UserId = userId)
-                select membership }
-        let withRole = query {
-            for membership in membershipQuery do
-                join memberRole in !! ctx.Languagedepot.MemberRoles
-                    on (membership.Id = memberRole.MemberId)
-                where (memberRole.RoleId = roleId)
-                select (Some memberRole)
-                headOrDefault
-        }
-        match withRole with
-        | Some _ -> () // Already exists, no need to change it
-        | None -> // add
-            // First, was there a membership record?
-            // If not, we need to add it *and* the corresponding role
-            let! maybeMember = membershipQuery |> Seq.tryHeadAsync
-            match maybeMember with
-            | Some membership ->
-                // User is a member already but with a different role
-                let memberRole = ctx.Languagedepot.MemberRoles.Create()
-                memberRole.MemberId <- membership.Id
-                memberRole.RoleId <- roleId
-                memberRole.InheritedFrom <- None
-                do! ctx.SubmitUpdatesAsync()
-            | None ->
-                // User is not yet a member under any role
-                let membership = ctx.Languagedepot.Members.Create()
-                membership.MailNotification <- 0y
-                membership.CreatedOn <- Some (System.DateTime.UtcNow)
-                membership.ProjectId <- projectId
-                membership.UserId <- userId
-                do! ctx.SubmitUpdatesAsync()  // Populate membership.Id
-                let memberRole = ctx.Languagedepot.MemberRoles.Create()
-                memberRole.MemberId <- membership.Id
-                memberRole.RoleId <- roleId
-                memberRole.InheritedFrom <- None
-                do! ctx.SubmitUpdatesAsync()
+        let! salt =
+            let sql = "SELECT salt FROM users where login = @username"
+            let setParams (cmd : MySqlCommand) =
+                cmd.Parameters.AddWithValue("username", changeRequest.username) |> ignore
+            doScalarQueryWithParams connString sql setParams |> Async.AwaitTask
+        let hashedPassword = PasswordHashing.hashPassword salt changeRequest.password
+        let sql = "UPDATE users SET hashed_password = @hashedPassword, must_change_passwd = @mustChangePassword, updated_on = NOW() WHERE login = @username"
+        let setParams (cmd : MySqlCommand) =
+            cmd.Parameters.AddWithValue("hashedPassword", hashedPassword) |> ignore
+            cmd.Parameters.AddWithValue("mustChangePassword", changeRequest.mustChangePassword |> Option.defaultValue false) |> ignore
+        let! result = doNonQueryWithParams connString sql setParams |> Async.AwaitTask
+        return (result = 1)
     }
 
-let removeMembershipImpl (connString : string) (membershipQuery : IQueryable<sql.dataContext.``languagedepot.membersEntity``>) =
+let removeMembership (connString : string) (username : string) (projectCode : string) =
     async {
-        let ctx = sql.GetDataContext connString
-        // If the Redmine table had proper foreign key relationships, we could use ON DELETE CASCADE and this would be a lot simpler.
-        // As it is, we have to go through a slightly convoluted process to delete the correct member_roles and members entries.
-        let! memberRolesToDelete =
-            query {
-                for membership in membershipQuery do
-                    join memberRole in !! ctx.Languagedepot.MemberRoles
-                        on (membership.Id = memberRole.MemberId)
-                    where (memberRole.MemberId = membership.Id)
-                    select (memberRole)
-            } |> List.executeQueryAsync
-        let! membershipsToDelete = membershipQuery |> List.executeQueryAsync
-        let memberRoleIdsToDelete = memberRolesToDelete |> List.map (fun mr -> mr.Id)
-        let membershipIdsToDelete = membershipsToDelete |> List.map (fun mr -> mr.Id)
-        let! _deleteCountMemberRoles =
-            query {
-                for memberRole in ctx.Languagedepot.MemberRoles do
-                    where (memberRole.Id |=| memberRoleIdsToDelete)  // The custom |=| operator translates to "item IN (list-of-items)" in SQL
-                    select (memberRole)
-            } |> Seq.``delete all items from single table``
-        let! _deleteCountMemberships =
-            query {
-                for membership in ctx.Languagedepot.Members do
-                    where (membership.Id |=| membershipIdsToDelete)
-                    select (membership)
-            } |> Seq.``delete all items from single table``
-        // Currently the delete counts are always 0 due to https://github.com/fsprojects/SQLProvider/issues/633 so there's no point in using them to confirm success or failure
-        // printfn "%d role entries and %d membership entries deleted" deleteCountMemberRoles deleteCountMemberships
+        use conn = new MySqlConnection(connString)
+        do! conn.OpenAsync() |> Async.AwaitTask
+        use transaction = conn.BeginTransaction()
+        let sql =
+            "SELECT id FROM members" +
+            " JOIN users ON users.id = members.user_id" +
+            " JOIN projects ON projects.id = members.project_id" +
+            " WHERE users.login = @username AND projects.identifier = @projectCode"
+        use cmd = new MySqlCommand(sql, conn, transaction)
+        cmd.Parameters.AddWithValue("username", username) |> ignore
+        cmd.Parameters.AddWithValue("projectCode", projectCode) |> ignore
+        use! reader = cmd.ExecuteReaderAsync() |> Async.AwaitTask
+        let! memberRowIds = reader :?> MySqlDataReader |> getSqlResult (fun reader -> reader.GetInt32(0)) |> Async.AwaitTask
+        // Also have to delete from member_roles table
+        let sql = "DELETE FROM member_roles WHERE member_id IN @memberRowIds"
+        use cmd = new MySqlCommand(sql, conn, transaction)
+        cmd.Parameters.AddWithValue("memberRowIds", memberRowIds) |> ignore
+        let! _ = cmd.ExecuteNonQueryAsync() |> Async.AwaitTask
+        let sql = "DELETE FROM members WHERE id IN @memberRowIds"
+        use cmd = new MySqlCommand(sql, conn, transaction)
+        cmd.Parameters.AddWithValue("memberRowIds", memberRowIds) |> ignore
+        let! _ = cmd.ExecuteNonQueryAsync() |> Async.AwaitTask
+        do! transaction.CommitAsync() |> Async.AwaitTask
         return ()
     }
 
-let removeMembershipById (connString : string) (userId : int) (projectId : int) (roleId : int) =
-    async {
-        let ctx = sql.GetDataContext connString
-        let membershipQuery = query {
-            for membership in ctx.Languagedepot.Members do
-                where (membership.ProjectId = projectId && membership.UserId = userId)
-                select membership }
-        do! removeMembershipImpl connString membershipQuery
+let addMembership (connString : string) (username : string) (projectCode : string) (roleName : string) =
+
+    let getId (sql : string) (paramName : string) (paramValue : string) (conn : MySqlConnection) (transaction: MySqlTransaction) = task {
+            use cmd = new MySqlCommand(sql, conn, transaction)
+            cmd.Parameters.AddWithValue(paramName, paramValue) |> ignore
+            use! reader = cmd.ExecuteReaderAsync()
+            let! ids = reader :?> MySqlDataReader |> getSqlResult (fun reader -> reader.GetInt32(0))
+            if ids.Length = 0 then
+                return -1
+            else
+                return ids.[0]
     }
 
-let removeUserFromAllRolesInProject (connString : string) (username : string) (projectCode : string) =
     async {
-        let ctx = sql.GetDataContext connString
-        let membershipQuery = query {
-            for membership in ctx.Languagedepot.Members do
-            join project in ctx.Languagedepot.Projects on (membership.ProjectId = project.Id)
-            join user in ctx.Languagedepot.Users on (membership.UserId = user.Id)
-            where (project.Identifier.IsSome && project.Identifier.Value = projectCode)
-            where (user.Login = username)
-            select membership }
-        do! removeMembershipImpl connString membershipQuery
-        return true
-    }
+        use conn = new MySqlConnection(connString)
+        do! conn.OpenAsync() |> Async.AwaitTask
+        use transaction = conn.BeginTransaction()
 
-let addOrRemoveMembership (isAdd : bool) (connString : string) (username : string) (projectCode : string) (roleType : RoleType) =
-    // Most of the code checking usernames and project codes and fetching numeric IDs is shared between add and remove operations
-    async {
-        let ctx = sql.GetDataContext connString
-        let roleId = roleType.ToNumericId()
-        let maybeUserId = query {
-            for user in ctx.Languagedepot.Users do
-                where (user.Login = username)
-                select (Some user.Id)
-                exactlyOneOrDefault }
-        let maybeProjectId = query {
-            for project in ctx.Languagedepot.Projects do
-                where (project.Status = ProjectStatus.Active &&
-                       project.Identifier.IsSome &&
-                       project.Identifier.Value = projectCode)
-                select (Some project.Id)
-                exactlyOneOrDefault }
-        match maybeUserId, maybeProjectId with
-        | None, _
-        | _, None ->
-            return false
-        | Some userId, Some projectId ->
-            let fn = if isAdd then addMembershipById else removeMembershipById
-            do! fn connString userId projectId roleId
-            return true
+        let! roleId = getId "SELECT id FROM roles WHERE name = @roleName" "roleName" roleName conn transaction |> Async.AwaitTask
+        let! userId = getId "SELECT id FROM users WHERE login = @username" "username" username conn transaction |> Async.AwaitTask
+        let! projId = getId "SELECT id FROM projects WHERE identifier = @projectCode" "projectCode" projectCode conn transaction |> Async.AwaitTask
+        if roleId < 0 || userId < 0 || projId < 0 then
+            // Can't do anything with invalid data
+            do! transaction.RollbackAsync() |> Async.AwaitTask
+            return ()
+        else
+            // First, check whether user is already a member
+            let sql =
+                "SELECT id FROM members" +
+                " JOIN users ON users.id = members.user_id" +
+                " JOIN projects ON projects.id = members.project_id" +
+                " WHERE users.login = @username AND projects.identifier = @projectCode"
+            use cmd = new MySqlCommand(sql, conn, transaction)
+            cmd.Parameters.AddWithValue("username", username) |> ignore
+            cmd.Parameters.AddWithValue("projectCode", projectCode) |> ignore
+            use! reader = cmd.ExecuteReaderAsync() |> Async.AwaitTask
+            let! memberRowIds = reader :?> MySqlDataReader |> getSqlResult (fun reader -> reader.GetInt32(0)) |> Async.AwaitTask
+            if memberRowIds.Length > 0 then
+                // Already a member; just update the membership role that user already has
+                let sql = "UPDATE member_roles SET role_id = @roleId WHERE member_id = @memberId"
+                use cmd = new MySqlCommand(sql, conn, transaction)
+                cmd.Parameters.AddWithValue("username", username) |> ignore
+                cmd.Parameters.AddWithValue("projectCode", projectCode) |> ignore
+                let! _ = cmd.ExecuteNonQueryAsync() |> Async.AwaitTask
+                do! transaction.CommitAsync() |> Async.AwaitTask
+                return ()
+            else
+                // Add new members *and* member_roles entries
+                let sql =
+                    "INSERT INTO members (user_id, project_id, created_on) " +
+                    "VALUES (@userId, @projectId, NOW())"
+                use cmd = new MySqlCommand(sql, conn, transaction)
+                cmd.Parameters.AddWithValue("userId", userId) |> ignore
+                cmd.Parameters.AddWithValue("projectId", projId) |> ignore
+                let! affectedRows = cmd.ExecuteNonQueryAsync() |> Async.AwaitTask
+                if affectedRows <= 0 then
+                    do! transaction.RollbackAsync() |> Async.AwaitTask
+                    return ()
+                let memberId = cmd.LastInsertedId
+                let sql =
+                    "INSERT INTO member_roles (member_id, role_id) " +
+                    "VALUES (@memberId, @roleId)"
+                use cmd = new MySqlCommand(sql, conn, transaction)
+                cmd.Parameters.AddWithValue("memberId", memberId) |> ignore
+                cmd.Parameters.AddWithValue("roleId", roleId) |> ignore
+                let! affectedRows = cmd.ExecuteNonQueryAsync() |> Async.AwaitTask
+                if affectedRows <= 0 then
+                    do! transaction.RollbackAsync() |> Async.AwaitTask
+                    return ()
+                else
+                    do! transaction.CommitAsync() |> Async.AwaitTask
+                    return ()
     }
 
 let archiveProject (connString : string) (projectCode : string) =
     async {
-        let ctx = sql.GetDataContext connString
-        let maybeProject = query {
-            for project in ctx.Languagedepot.Projects do
-                where (not project.Identifier.IsNone)
-                where (project.Identifier.Value = projectCode)
-                select (Some project)
-                exactlyOneOrDefault }
-        match maybeProject with
-        | None -> return false
-        | Some project ->
-            project.Status <- ProjectStatus.Archived
-            do! ctx.SubmitUpdatesAsync()
+        use conn = new MySqlConnection(connString)
+        do! conn.OpenAsync() |> Async.AwaitTask
+        use transaction = conn.BeginTransaction()
+
+        let sql = sprintf "UPDATE projects SET status = @status WHERE identifier = @projectCode"
+        let setParams (cmd : MySqlCommand) =
+            cmd.Parameters.AddWithValue("status", ProjectStatus.Archived) |> ignore
+            cmd.Parameters.AddWithValue("projectCode", projectCode) |> ignore
+        let! affectedRows = doNonQueryWithParams connString sql setParams |> Async.AwaitTask
+        if affectedRows > 0 then
+            do! transaction.CommitAsync() |> Async.AwaitTask
             return true
+        else
+            do! transaction.RollbackAsync() |> Async.AwaitTask
+            return false
     }
 
 // NOTE: If you change the database schema, you must UNCOMMENT the next two lines and then
@@ -620,6 +674,7 @@ module ModelRegistration =
     open Microsoft.Extensions.DependencyInjection.Extensions
 
     let registerServices (builder : IServiceCollection) (connString : string) =
+        // We need to turn off MySQL's ONLY_FULL_GROUP_BY setting for our entire session
         builder
             .RemoveAll<ListUsers>()
             .AddSingleton<ListUsers>(manualUsersQuery)
@@ -666,9 +721,9 @@ module ModelRegistration =
             .RemoveAll<VerifyLoginCredentials>()
             .AddSingleton<VerifyLoginCredentials>(verifyLoginInfo)
             .RemoveAll<AddMembership>()
-            .AddSingleton<AddMembership>(AddMembership (addOrRemoveMembership true))
+            .AddSingleton<AddMembership>(AddMembership addMembership)
             .RemoveAll<RemoveMembership>()
-            .AddSingleton<RemoveMembership>(RemoveMembership (addOrRemoveMembership false))
+            .AddSingleton<RemoveMembership>(RemoveMembership removeMembership)
             .RemoveAll<RemoveUserFromAllRolesInProject>()
             .AddSingleton<RemoveUserFromAllRolesInProject>(RemoveUserFromAllRolesInProject (removeUserFromAllRolesInProject))
             .RemoveAll<ArchiveProject>()

--- a/src/Server/Server.fs
+++ b/src/Server/Server.fs
@@ -52,9 +52,8 @@ let webApp = router {
     patchf "/api/project/%s" (fun projId -> bindJson<Api.EditProjectMembershipApiCall> (Controller.addOrRemoveUserFromProject projId))
     // Suggested by Chris Hirt: POST to add, DELETE to remove, no JSON body needed
     postf "/api/project/%s/user/%s/withRole/%s" Controller.addUserToProjectWithRole
-    deletef "/api/project/%s/user/%s/withRole/%s" Controller.removeUserFromOneRoleInProject
-    postf "/api/project/%s/user/%s" Controller.addUserToProject  // Default role is "contributor"
-    deletef "/api/project/%s/user/%s" Controller.removeUserFromAllRolesInProject
+    postf "/api/project/%s/user/%s" Controller.addUserToProject  // Default role is "Contributer", yes, spelled with "er"
+    deletef "/api/project/%s/user/%s" Controller.removeUserFromProject
     postf "/api/users/%s/projects/withRole/%s" (fun (username,roleName) -> bindJson<Api.LoginCredentials> (Controller.projectsAndRolesByUserRole username roleName))
     get "/api/roles" Controller.getAllRoles
     post "/api/users" (bindJson<Api.CreateUser> Controller.createUser)

--- a/src/Server/Server.fs
+++ b/src/Server/Server.fs
@@ -13,6 +13,7 @@ open Giraffe.HttpStatusCodeHandlers
 open Saturn
 open Shared
 open Shared.Settings
+open Thoth.Json.Net
 
 let tryGetEnv = System.Environment.GetEnvironmentVariable >> function null | "" -> None | x -> Some x
 
@@ -83,13 +84,17 @@ let hostConfig (builder : IWebHostBuilder) =
         .ConfigureAppConfiguration(setupAppConfig)
         .ConfigureServices(registerMySqlServices)
 
+let extraJsonCoders =
+    Extra.empty
+    |> Extra.withInt64
+
 let app = application {
     url ("http://0.0.0.0:" + port.ToString() + "/")
     use_router webApp
     memory_cache
     disable_diagnostics  // Don't create site.map file
     error_handler errorHandler
-    use_json_serializer(Thoth.Json.Giraffe.ThothSerializer())
+    use_json_serializer(Thoth.Json.Giraffe.ThothSerializer(extra=extraJsonCoders))
     use_gzip
     host_config hostConfig
     use_config buildConfig // TODO: Get rid of this

--- a/src/Shared/SampleData.fs
+++ b/src/Shared/SampleData.fs
@@ -101,81 +101,81 @@ let Projects : Shared.Dto.ProjectList = [|
     { code = "ld-test"
       name = "LD Test"
       description = "LD API Test project"
-      membership = new System.Collections.Generic.Dictionary<string,string>() }
+      membership = Map.empty }
 
     { code = "test-ld-dictionary"
       name = "LD Test Dictionary"
       description = "LD API Test Dictionary project"
-      membership = dict ["manager1", "Manager"; "user1", "Contributor"; "test", "Contributor"] }
+      membership = Map.ofList ["manager1", "Manager"; "user1", "Contributor"; "test", "Contributor"] }
 
     { code = "test-ld-flex"
       name = "LD API Test Flex"
       description = "LD API Test FLEx project"
-      membership = dict ["manager2", "Manager"; "user2", "Contributor"; "test", "Manager"] }
+      membership = Map.ofList ["manager2", "Manager"; "user2", "Contributor"; "test", "Manager"] }
 
     { code = "test-ld-demo"
       name = "LD API Test Demo"
       description = "LD API Test Demo project"
-      membership = dict ["test", "LanguageDepotProgrammer"; "test", "Manager"] }
+      membership = Map.ofList ["test", "LanguageDepotProgrammer"; "test", "Manager"] }
 
     { code = "test-ld-adapt"
       name = "LD API Test AdaptIT"
       description = "LD API Test AdaptIT project"
-      membership = new System.Collections.Generic.Dictionary<string,string>() }
+      membership = Map.empty }
 
     { code = "test-ld-training"
       name = "LD API Test Training"
       description = "LD API Test Training project"
-      membership = new System.Collections.Generic.Dictionary<string,string>() }
+      membership = Map.empty }
 
     { code = "test-ld-ütf8"
       name = "LD API UTF8 Eñcoding"
       description = "LD API Test UTF8 Eñcoding project"
-      membership = dict ["test", "Manager"] }
+      membership = Map.ofList ["test", "Manager"] }
 
     { code = "tha-food"
       name = "Thai Food Dictionary"
       description = "A picture dictionary of Thai food."
-      membership = dict ["richard", "Manager"; "tuck", "Manager"; "user1", "Contributor"; "guest-palaso", "Observer"; "rhood", "LanguageDepotProgrammer"] }
+      membership = Map.ofList ["richard", "Manager"; "tuck", "Manager"; "user1", "Contributor"; "guest-palaso", "Observer"; "rhood", "LanguageDepotProgrammer"] }
 
     { code = "test-sherwood-sena-03"
       name = "Sherwood TestSena3 03"
       description = ""
-      membership = dict ["willscarlet", "Manager"; "rhood", "Manager"; "tuck", "Contributor"] }
+      membership = Map.ofList ["willscarlet", "Manager"; "rhood", "Manager"; "tuck", "Contributor"] }
 
     { code = "test-ws-1-flex"
       name = "test-ws-1-flex"
       description = ""
-      membership = dict ["willscarlet", "Manager"] }
+      membership = Map.ofList ["willscarlet", "Manager"] }
 
     { code = "robin-test-projects"
       name = "Robin Test Projects"
       description = "Test projects for Robin Hood's testing of Send/Receive scenarios"
-      membership = dict ["rhood", "Manager"] }
+      membership = Map.ofList ["rhood", "Manager"] }
 
     { code = "test-robin-flex-new-public"
       name = "Robin Test FLEx new public"
       description = ""
-      membership = dict ["rhood", "Manager"] }
+      membership = Map.ofList ["rhood", "Manager"] }
 
     { code = "test-robin-new-public-2"
       name = "Robin new public 2"
       description = ""
-      membership = dict ["rhood", "Manager"] }
+      membership = Map.ofList ["rhood", "Manager"] }
 
     { code = "alan_test"
       name = "Alan_test"
       description = "To test hg pull/push"
-      membership = dict ["adale", "Manager"] }
+      membership = Map.ofList ["adale", "Manager"] }
 
     { code = "aland_test"
       name = "aland_test"
       description = "hg pull/push tests"
-      membership = dict ["adale", "Manager"] }
+      membership = Map.ofList ["adale", "Manager"] }
 
     { code = "tha-food2"
       name = "tha-food2"
       description = ""
-      membership = dict ["tuck", "Manager"] }
+      membership = Map.ofList ["tuck", "Manager"] }
 
 |]

--- a/src/Shared/SampleData.fs
+++ b/src/Shared/SampleData.fs
@@ -2,7 +2,18 @@ module SampleData
 
 open Shared
 
-let Users : Shared.Dto.UserList = [
+let StandardRoles : Shared.Dto.RoleDetails[] = [|
+    { name = "Manager"
+      id = 3 }
+    { name = "Contributor"
+      id = 4 }
+    { name = "Observer"
+      id = 5 }
+    { name = "LanguageDepotProgrammer"
+      id = 6 }
+|]
+
+let Users : Shared.Dto.UserList = [|
     { username = "admin"
       firstName = "Admin"
       lastName = "User"
@@ -83,88 +94,88 @@ let Users : Shared.Dto.UserList = [
       lastName = "a Dale"
       email = Some "alan_a_dale@example.org"
       language = "en" }
-]
+|]
 
-let Projects : Shared.Dto.ProjectList = [
+let Projects : Shared.Dto.ProjectList = [|
 
     { code = "ld-test"
       name = "LD Test"
       description = "LD API Test project"
-      membership = Some [] }
+      membership = new System.Collections.Generic.Dictionary<string,string>() }
 
     { code = "test-ld-dictionary"
       name = "LD Test Dictionary"
       description = "LD API Test Dictionary project"
-      membership = Some ["manager1", Manager; "user1", Contributor; "test", Contributor] }
+      membership = dict ["manager1", "Manager"; "user1", "Contributor"; "test", "Contributor"] }
 
     { code = "test-ld-flex"
       name = "LD API Test Flex"
       description = "LD API Test FLEx project"
-      membership = Some ["manager2", Manager; "user2", Contributor; "test", Manager] }
+      membership = dict ["manager2", "Manager"; "user2", "Contributor"; "test", "Manager"] }
 
     { code = "test-ld-demo"
       name = "LD API Test Demo"
       description = "LD API Test Demo project"
-      membership = Some ["test", Programmer; "test", Manager] }
+      membership = dict ["test", "LanguageDepotProgrammer"; "test", "Manager"] }
 
     { code = "test-ld-adapt"
       name = "LD API Test AdaptIT"
       description = "LD API Test AdaptIT project"
-      membership = Some [] }
+      membership = new System.Collections.Generic.Dictionary<string,string>() }
 
     { code = "test-ld-training"
       name = "LD API Test Training"
       description = "LD API Test Training project"
-      membership = Some [] }
+      membership = new System.Collections.Generic.Dictionary<string,string>() }
 
     { code = "test-ld-ütf8"
       name = "LD API UTF8 Eñcoding"
       description = "LD API Test UTF8 Eñcoding project"
-      membership = Some ["test", Manager] }
+      membership = dict ["test", "Manager"] }
 
     { code = "tha-food"
       name = "Thai Food Dictionary"
       description = "A picture dictionary of Thai food."
-      membership = Some ["richard", Manager; "tuck", Manager; "user1", Contributor; "guest-palaso", Observer; "rhood", Programmer] }
+      membership = dict ["richard", "Manager"; "tuck", "Manager"; "user1", "Contributor"; "guest-palaso", "Observer"; "rhood", "LanguageDepotProgrammer"] }
 
     { code = "test-sherwood-sena-03"
       name = "Sherwood TestSena3 03"
       description = ""
-      membership = Some ["willscarlet", Manager; "rhood", Manager; "tuck", Contributor] }
+      membership = dict ["willscarlet", "Manager"; "rhood", "Manager"; "tuck", "Contributor"] }
 
     { code = "test-ws-1-flex"
       name = "test-ws-1-flex"
       description = ""
-      membership = Some ["willscarlet", Manager] }
+      membership = dict ["willscarlet", "Manager"] }
 
     { code = "robin-test-projects"
       name = "Robin Test Projects"
       description = "Test projects for Robin Hood's testing of Send/Receive scenarios"
-      membership = Some ["rhood", Manager] }
+      membership = dict ["rhood", "Manager"] }
 
     { code = "test-robin-flex-new-public"
       name = "Robin Test FLEx new public"
       description = ""
-      membership = Some ["rhood", Manager] }
+      membership = dict ["rhood", "Manager"] }
 
     { code = "test-robin-new-public-2"
       name = "Robin new public 2"
       description = ""
-      membership = Some ["rhood", Manager] }
+      membership = dict ["rhood", "Manager"] }
 
     { code = "alan_test"
       name = "Alan_test"
       description = "To test hg pull/push"
-      membership = Some ["adale", Manager] }
+      membership = dict ["adale", "Manager"] }
 
     { code = "aland_test"
       name = "aland_test"
       description = "hg pull/push tests"
-      membership = Some ["adale", Manager] }
+      membership = dict ["adale", "Manager"] }
 
     { code = "tha-food2"
       name = "tha-food2"
       description = ""
-      membership = Some ["tuck", Manager] }
+      membership = dict ["tuck", "Manager"] }
 
-]
+|]

--- a/src/Shared/Shared.fs
+++ b/src/Shared/Shared.fs
@@ -92,6 +92,14 @@ module Dto =
 
     type MemberList = (string * RoleType) list
 
+    type ProjectDetailsInternal = {
+        code : string
+        name : string
+        description : string
+        // ``type`` : ProjectType  // TODO: Decide if we want this one or not
+        membership : System.Collections.Generic.Dictionary<string,string>  // Keys will be usernames and values will be role names
+    }
+
     type ProjectDetails = {
         code : string
         name : string

--- a/src/Shared/Shared.fs
+++ b/src/Shared/Shared.fs
@@ -88,16 +88,16 @@ module Dto =
         language : string // (interface language for this user) - is this useful to the frontend? ... yeah, because when you log in, the front end wants to know who logged in and what language to give you
     }
 
-    type UserList = UserDetails list
+    type UserList = UserDetails[]
 
-    type MemberList = (string * RoleType) list
+    // type MemberList = (string * RoleType) list
 
     type ProjectDetailsInternal = {
         code : string
         name : string
         description : string
         // ``type`` : ProjectType  // TODO: Decide if we want this one or not
-        membership : System.Collections.Generic.Dictionary<string,string>  // Keys will be usernames and values will be role names
+        membership : System.Collections.Generic.IDictionary<string,string>  // Keys will be usernames and values will be role names
     }
 
     type ProjectDetails = {
@@ -105,27 +105,15 @@ module Dto =
         name : string
         description : string
         // ``type`` : ProjectType  // TODO: Decide if we want this one or not
-        membership : MemberList option  // Because we'll sometimes want the membership list, and sometimes not. Only supplied if we asked for it in the request API, otherwise it's None/omitted
+        membership : System.Collections.Generic.IDictionary<string,string>  // Keys will be usernames and values will be role names. Only supplied if we asked for it in the request API, otherwise it's empty.
     }
 
-    type ProjectList = ProjectDetails list  // Depending on the situation, this will sometimes include MemberLists and sometimes it won't (e.g., list all projects vs. list one's I'm a member of)
+    type ProjectList = ProjectDetails[]  // Depending on the situation, this will sometimes include MemberLists and sometimes it won't (e.g., list all projects vs. list one's I'm a member of)
 
     type RoleDetails = {
+        id : int
         name : string
-        ``type`` : RoleType
     }
-
-    let standardRoles : RoleDetails list = [
-        { name = "Manager"
-          ``type`` = Manager }
-        { name = "Contributor"
-          ``type`` = Contributor }
-        { name = "LanguageDepotProgrammer"
-          ``type`` = Programmer }
-        { name = "Observer"
-          ``type`` = Observer }
-    ]
-    // Hard-coded so we don't have to hit MySQL for something that hasn't changed in years.
 
 module Api =
     type LoginCredentials = {
@@ -138,7 +126,7 @@ module Api =
         code : string
         name : string
         description : string option
-        initialMembers : Dto.MemberList option
+        initialMembers : System.Collections.Generic.Dictionary<string,string>
     }
 
     type ArchiveProject = {

--- a/src/Shared/Shared.fs
+++ b/src/Shared/Shared.fs
@@ -92,20 +92,12 @@ module Dto =
 
     // type MemberList = (string * RoleType) list
 
-    type ProjectDetailsInternal = {
-        code : string
-        name : string
-        description : string
-        // ``type`` : ProjectType  // TODO: Decide if we want this one or not
-        membership : System.Collections.Generic.IDictionary<string,string>  // Keys will be usernames and values will be role names
-    }
-
     type ProjectDetails = {
         code : string
         name : string
         description : string
         // ``type`` : ProjectType  // TODO: Decide if we want this one or not
-        membership : System.Collections.Generic.IDictionary<string,string>  // Keys will be usernames and values will be role names. Only supplied if we asked for it in the request API, otherwise it's empty.
+        membership : Map<string,string>  // Keys are usernames, values are role names. Only supplied if we asked for it in the request API, otherwise it's empty.
     }
 
     type ProjectList = ProjectDetails[]  // Depending on the situation, this will sometimes include MemberLists and sometimes it won't (e.g., list all projects vs. list one's I'm a member of)
@@ -126,7 +118,7 @@ module Api =
         code : string
         name : string
         description : string option
-        initialMembers : System.Collections.Generic.Dictionary<string,string>
+        initialMembers : Map<string,string>
     }
 
     type ArchiveProject = {

--- a/testlanguagedepot.sql
+++ b/testlanguagedepot.sql
@@ -1168,7 +1168,6 @@ INSERT INTO `projects` (`id`, `name`, `description`, `homepage`, `is_public`, `p
 (5, 'LD API Test AdaptIT', 'LD API Test AdaptIT project', '', 1, NULL, '2014-09-21 02:44:47', '2017-02-24 02:44:47', 'test-ld-adapt', 1, 9, 10, 0, NULL, NULL),
 (6, 'LD API Test Training', 'LD API Test Training project', '', 1, NULL, '2015-09-21 02:44:47', '2017-02-24 02:44:47', 'test-ld-training', 1, 11, 12, 0, NULL, NULL),
 (7, 'LD API UTF8 Eñcoding', 'LD API Test UTF8 Eñcoding project', '', 1, NULL, '2016-08-10 07:30:45', '2017-03-01 08:10:20', 'test-ld-ütf8', 1, 13, 14, 0, NULL, NULL),
-(8, 'Missing project', NULL, NULL, 0, NULL, NULL, NULL, NULL, 1, NULL, NULL, 0, NULL, NULL),
 (9,'Thai Food Dictionary','A picture dictionary of Thai food.','',1,NULL,'2009-10-12 03:41:53','2019-10-04 13:22:14','tha-food',1,17,18,0,NULL,NULL),
 (1289,'Sherwood TestSena3 03','','',1,NULL,'2016-08-25 07:58:11','2019-10-04 13:22:22','test-sherwood-sena-03',1,2379,2380,0,NULL,NULL),
 (1894,'test-ws-1-flex','','',1,NULL,'2018-07-23 09:31:24','2019-10-04 13:22:26','test-ws-1-flex',1,3513,3514,0,NULL,NULL),


### PR DESCRIPTION
Now that we've made the decision to only support users having a single role in a project (as opposed to multiple roles the way Redmine 4 allows), that simplifies the shape of the API we need. New API shape:

```javascript
{"code":"test-project",
 "name":"Test Project",
 "description":"Sample project for testing",
 "membership":{"rmunn":"Manager","testuser":"Contributer"}}
```