### PR TITLE
Add a backwards-compatibility API endpoint

### DIFF
--- a/src/Server/Controller.fs
+++ b/src/Server/Controller.fs
@@ -140,6 +140,12 @@ let projectsAndRolesByUser username (loginCredentials : Api.LoginCredentials) : 
     withLoggedInServiceFunc true loginCredentials
         (fun connString (projectsAndRolesByUser : Model.ProjectsAndRolesByUser) -> projectsAndRolesByUser connString username)
 
+let legacyProjectsAndRolesByUser username (legacyLoginCredentials : Api.LegacyLoginCredentials) : HttpHandler =
+    let loginCredentials : Api.LoginCredentials =
+        { username = username
+          password = legacyLoginCredentials.password }
+    projectsAndRolesByUser username loginCredentials
+
 let projectsAndRolesByUserRole username roleName (loginCredentials : Api.LoginCredentials) : HttpHandler =
     withLoggedInServiceFunc true loginCredentials
         (fun connString (projectsAndRolesByUserRole : Model.ProjectsAndRolesByUserRole) -> projectsAndRolesByUserRole connString username roleName)

--- a/src/Server/Server.fs
+++ b/src/Server/Server.fs
@@ -56,6 +56,8 @@ let webApp = router {
     getf "/api/users/exists/%s" Controller.userExists
     postf "/api/users/%s/projects" (fun username -> bindJson<Api.LoginCredentials> (Controller.projectsAndRolesByUser username))
     postf "/api/users/%s/projects/withRole/%s" (fun (username,roleName) -> bindJson<Api.LoginCredentials> (Controller.projectsAndRolesByUserRole username roleName))
+    // Backwards compatibility (old API used /api/user/{username}/projects with just the password in JSON)
+    postf "/api/user/%s/projects" (fun username -> bindJson<Api.LegacyLoginCredentials> (Controller.legacyProjectsAndRolesByUser username))
     patchf "/api/project/%s" (fun projId -> bindJson<Api.EditProjectMembershipApiCall> (Controller.addOrRemoveUserFromProject projId))
     // Suggested by Chris Hirt: POST to add, DELETE to remove, no JSON body needed
     postf "/api/project/%s/user/%s/withRole/%s" Controller.addUserToProjectWithRole

--- a/src/Shared/Shared.fs
+++ b/src/Shared/Shared.fs
@@ -109,6 +109,10 @@ module Api =
         password : string
     }
 
+    type LegacyLoginCredentials = {
+        password : string
+    }
+
     type CreateProject = {
         login : LoginCredentials // TODO : Use "username" rather than "login" for login field in Redmine's users table
         code : string


### PR DESCRIPTION
The new API has gone to `/api/users/(username)/projects`, but the old API was using `/api/user/(username)/projects` with a slightly different JSON payload. This PR will add an API endpoint at `/api/user/...` so that existing projects (e.g., Language Forge) will have an easier time transitioning.