### PR TITLE
GitHub Actions workflow to publish Docker image

### DIFF
--- a/.github/workflows/deploy-to-docker-hub.yml
+++ b/.github/workflows/deploy-to-docker-hub.yml
@@ -1,0 +1,29 @@
+name: Deploy to Docker Hub
+
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build app
+        # We use "npm run" so that we can get the version number out of package.json
+        run: npm run docker
+
+      - name: List images
+        run: docker images
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Publish to Docker Hub
+        run: docker image push --all-tags sillsdev/web-languagedepot-api

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"license": "MIT",
 	"scripts": {
 		"dev": "svelte-kit dev",
+		"docker": "docker build -t sillsdev/web-languagedepot-api:$npm_package_version -t sillsdev/web-languagedepot-api:latest .",
 		"test": "mocha",
 		"build": "svelte-kit build",
 		"start": "svelte-kit start",


### PR DESCRIPTION
We're ready to publish the image to Docker Hub now. We'll start bumping the version number from 0.0.1 upwards with every new feature or bugfix. The `package.json` file will be the single source of truth for our version number.