### PR TITLE
Improve API security

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-ldapi",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"description": "An API for Language Depot, written in node.js",
 	"main": "build/index.js",
 	"author": "Robin Munn <robin_munn@sil.org>",

--- a/src/lib/utils/db/authRules.js
+++ b/src/lib/utils/db/authRules.js
@@ -3,7 +3,7 @@ import { authTokenRequired, missingRequiredParam, notAllowed } from '$lib/utils/
 import { retryOnServerError } from '$lib/utils/commonSqlHandlers';
 import { verifyBasicAuth, verifyJwtAuth } from './auth';
 
-export async function getMemberRoleInProject(db, { projectCode, username } = {}) {
+export async function getMemberRoleInProject(db, { projectCode = undefined, username = undefined } = {}) {
     if (!projectCode || !username) {
         return undefined;
     }
@@ -46,7 +46,7 @@ export function isAdmin(authUser) {
 }
 
 // Helpers for quick-and-easy auth
-export async function allowManagerOrAdmin(db, { params, headers } = {}) {
+export async function allowManagerOrAdmin(db, { params = undefined, headers = undefined } = {}) {
     if (!params || !params.projectCode) {
         return missingRequiredParam('projectCode');
     }
@@ -66,7 +66,7 @@ export async function allowManagerOrAdmin(db, { params, headers } = {}) {
     return { status: 200, authUser };
 }
 
-export async function allowSameUserOrAdmin(db, { params, headers, allowBasicAuth } = {}) {
+export async function allowSameUserOrAdmin(db, { params = undefined, headers = undefined, allowBasicAuth = false } = {}) {
     if (!params || !params.username) {
         return missingRequiredParam('username');
     }

--- a/src/lib/utils/db/projects.js
+++ b/src/lib/utils/db/projects.js
@@ -5,7 +5,7 @@ import { verifyJwtAuth } from './auth';
 import { allowManagerOrAdmin } from './authRules';
 import { addUserWithRole, removeUserFromProject } from './usersAndRoles';
 
-export function allProjectsQuery(db, { limit, offset } = {}) {
+export function allProjectsQuery(db, { limit = undefined, offset = undefined } = {}) {
     let query = Project.query(db);
     if (limit) {
         query = query.limit(limit);

--- a/src/lib/utils/db/users.js
+++ b/src/lib/utils/db/users.js
@@ -42,6 +42,7 @@ export async function createUser(db, username, newUser) {
         return { status: 201, body: result };
     },
     async (user) => {
+        // TODO: Check JWT - only same user or admin should be able to update one's account details
         const result = await retryOnServerError(User.query(trx).updateAndFetchById(user.id, newUser));
         return { status: 200, body: result };
     });
@@ -61,6 +62,7 @@ export async function patchUser(db, username, updateData) {
         return cannotUpdateMissing(username, 'user');
     },
     async (user) => {
+        // TODO: Check JWT - only same user or admin should be able to update one's account details
         const result = await retryOnServerError(User.query(trx).patchAndFetchById(user.id, updateData));
         return { status: 200, body: result };
     });
@@ -81,6 +83,7 @@ export async function deleteUser(db, username) {
         return { status: 204, body: {} };
     },
     async (user) => {
+        // TODO: Check JWT - only same user or admin should be able to update one's account details
         // Delete memberships and email addresses first so there's never any DB inconsistency
         const membershipsQuery = Membership.query(trx).where('user_id', user.id).select('id')
         await retryOnServerError(MemberRole.query(trx).whereIn('member_id', membershipsQuery).delete());

--- a/src/lib/utils/db/users.js
+++ b/src/lib/utils/db/users.js
@@ -2,7 +2,7 @@ import { User, Membership, MemberRole, Email } from '$lib/db/models';
 import { cannotUpdateMissing } from '$lib/utils/commonErrors';
 import { atMostOne, onlyOne, catchSqlError, retryOnServerError } from '$lib/utils/commonSqlHandlers';
 
-export function allUsersQuery(db, { limit, offset } = {}) {
+export function allUsersQuery(db, { limit = undefined, offset = undefined } = {}) {
     let query = User.query(db);
     if (limit) {
         query = query.limit(limit);

--- a/src/lib/utils/db/users.js
+++ b/src/lib/utils/db/users.js
@@ -67,7 +67,7 @@ export async function patchUser(db, username, updateData) {
         return cannotUpdateMissing(username, 'user');
     },
     async (user) => {
-        // TODO: Check JWT - only same user or admin should be able to update one's account details
+        // No need to check JWT in this function, as it's checked in the caller
         const result = await retryOnServerError(User.query(trx).patchAndFetchById(user.id, updateData));
         return { status: 200, body: result };
     });
@@ -88,7 +88,7 @@ export async function deleteUser(db, username) {
         return { status: 204, body: {} };
     },
     async (user) => {
-        // TODO: Check JWT - only same user or admin should be able to update one's account details
+        // No need to check JWT in this function, as it's checked in the caller
         // Delete memberships and email addresses first so there's never any DB inconsistency
         const membershipsQuery = Membership.query(trx).where('user_id', user.id).select('id')
         await retryOnServerError(MemberRole.query(trx).whereIn('member_id', membershipsQuery).delete());

--- a/src/lib/utils/db/users.js
+++ b/src/lib/utils/db/users.js
@@ -1,6 +1,7 @@
 import { User, Membership, MemberRole, Email } from '$lib/db/models';
 import { cannotUpdateMissing } from '$lib/utils/commonErrors';
 import { atMostOne, onlyOne, catchSqlError, retryOnServerError } from '$lib/utils/commonSqlHandlers';
+import { allowSameUserOrAdmin } from './authRules';
 
 export function allUsersQuery(db, { limit = undefined, offset = undefined } = {}) {
     let query = User.query(db);
@@ -33,7 +34,7 @@ export function getOneUser(db, username) {
     return onlyOne(query, 'username', 'username', user => ({ status: 200, body: user }));
 }
 
-export async function createUser(db, username, newUser) {
+export async function createUser(db, username, newUser, headers) {
     const trx = await User.startTransaction(db);
     const query = oneUserQuery(trx, username).select('id').forUpdate();
     const result = await atMostOne(query, 'username', 'username',
@@ -42,9 +43,13 @@ export async function createUser(db, username, newUser) {
         return { status: 201, body: result };
     },
     async (user) => {
-        // TODO: Check JWT - only same user or admin should be able to update one's account details
-        const result = await retryOnServerError(User.query(trx).updateAndFetchById(user.id, newUser));
-        return { status: 200, body: result };
+        const authResult = await allowSameUserOrAdmin(db, { params: { username }, headers });
+        if (authResult.status === 200) {
+            const result = await retryOnServerError(User.query(trx).updateAndFetchById(user.id, newUser));
+            return { status: 200, body: result };
+        } else {
+            return authResult;
+        }
     });
     if (result && result.status && result.status >= 200 && result.status < 400) {
         await trx.commit();

--- a/src/lib/utils/db/usersAndRoles.js
+++ b/src/lib/utils/db/usersAndRoles.js
@@ -87,7 +87,7 @@ async function removeUserFromProjectByProjectCode(db, projectCode, username) {
     return result;
 }
 
-function getProjectsForUser(db, { username, rolename } = {}) {
+function getProjectsForUser(db, { username = '', rolename = undefined } = {}) {
     return catchSqlError(async () => {
         let query = User.query(db)
             .withGraphJoined('memberships.[project, role]')

--- a/src/routes/api/v2/login.js
+++ b/src/routes/api/v2/login.js
@@ -2,6 +2,8 @@ import { dbs } from '$lib/db/dbsetup';
 import { basicAuthRequired, notAllowed } from '$lib/utils/commonErrors';
 import { verifyBasicAuth, makeJwt } from '$lib/utils/db/auth';
 
+// GET /api/v2/login - verify HTTP basic auth and, if password matches, return JWT token allowing API access for one week
+// Security: anyone may access, but only valid logins will be given a JWT token
 export async function get({ query, headers }) {
     const db = query.private ? dbs.private : dbs.public;
     const authUser = await verifyBasicAuth(db, headers);

--- a/src/routes/api/v2/projects/[projectCode]/index.js
+++ b/src/routes/api/v2/projects/[projectCode]/index.js
@@ -7,6 +7,8 @@ import { allowManagerOrAdmin } from '$lib/utils/db/authRules';
 import { getOneProject, createOneProject, patchOneProject, deleteOneProject } from '$lib/utils/db/projects';
 import { canonicalizeMembershipList, InvalidMemberships } from '$lib/utils/db/usersAndRoles';
 
+// GET /api/v2/projects/{projectCode} - JSON representation of a single project (requires manager or admin rights)
+// Security: must be a project manager on the project in question, or a site admin
 export async function get({ params, path, query, headers }) {
     if (!params.projectCode) {
         return missingRequiredParam('projectCode', path);
@@ -20,6 +22,8 @@ export async function get({ params, path, query, headers }) {
     }
 }
 
+// HEAD /api/v2/projects/{projectCode} - check whether project exists. Returns 200 if exists, 404 if not found. Response has no body; only HTTP status code is meaningful.
+// Security: anonymous access allowed
 export async function head({ params, query }) {
     if (!params.projectCode) {
         return { status: 400, body: {} };
@@ -35,6 +39,8 @@ export async function head({ params, query }) {
     }
 }
 
+// PUT /api/v2/projects/{projectCode} - create project, or update project if it aleady exists.
+// Security: anyone may create a project, and they become the project's first manager. Updating is restricted to existing project managers or site admins.
 export async function put({ path, params, body, query, headers }) {
     if (typeof body !== 'object') {
         return jsonRequired('PUT', path);
@@ -54,6 +60,10 @@ export async function put({ path, params, body, query, headers }) {
     // Here we don't return Content-Location because the client already knows it
 }
 
+// PATCH /api/v2/projects/{projectCode} - update project membership, possibly in bulk
+// TODO: Document JSON "shapes" allowed for project membership (many possibilities)
+// Security: must be a project manager on the project in question, or a site admin
+// TODO: Move security check earlier in function so we can reject fast if not allowed
 export async function patch({ path, params, body, query, headers }) {
     if (typeof body !== 'object') {
         return jsonRequired('PATCH', path);

--- a/src/routes/api/v2/projects/[projectCode]/user/[username]/index.js
+++ b/src/routes/api/v2/projects/[projectCode]/user/[username]/index.js
@@ -3,11 +3,11 @@ import { dbs } from '$lib/db/dbsetup';
 import { missingRequiredParam } from '$lib/utils/commonErrors';
 import { onlyOne } from '$lib/utils/commonSqlHandlers';
 import { addUserWithRoleByProjectCode, removeUserFromProjectByProjectCode } from '$lib/utils/db/usersAndRoles';
+import { allowSameUserOrProjectManagerOrAdmin } from '$lib/utils/db/authRules';
 
 // GET /api/v2/projects/{projectCode}/user/{username} - return user's role
 // Security: must be user whose role is being looked up, a project manager on the project in question, or a site admin
-// TODO: Add security check
-export async function get({ params, query }) {
+export async function get({ params, query, headers }) {
     if (!params || !params.projectCode) {
         return missingRequiredParam('projectCode', 'URL');
     }
@@ -15,15 +15,21 @@ export async function get({ params, query }) {
         return missingRequiredParam('username', 'URL');
     }
     const db = query.private ? dbs.private : dbs.public;
-    const dbQuery = Project.query(db)
-        .where('identifier', params.projectCode)
-        .withGraphJoined('members.[user, role]')
-        ;
-    return onlyOne(dbQuery, 'projectCode', 'project code',
-    async (project) => {
-        const users = project.members.filter(member => member.user.login === params.username && member.role && member.role.name);
-        return onlyOne(users, 'username', 'username', (member) => ({ status: 200, body: { user: member.user, role: member.role.name }}));
-    });
+    const authResult = await allowSameUserOrProjectManagerOrAdmin(db, { params, headers });
+    if (authResult.status === 200) {
+        const dbQuery = Project.query(db)
+            .where('identifier', params.projectCode)
+            .withGraphJoined('members.[user, role]')
+            ;
+        const x = allowSameUserOrProjectManagerOrAdmin
+        return onlyOne(dbQuery, 'projectCode', 'project code',
+        async (project) => {
+            const users = project.members.filter(member => member.user.login === params.username && member.role && member.role.name);
+            return onlyOne(users, 'username', 'username', (member) => ({ status: 200, body: { user: member.user, role: member.role.name }}));
+        });
+    } else {
+        return authResult;
+    }
 }
 
 // TODO: HEAD /api/v2/projects/{projectCode}/user/{username} - is user a member of the project?
@@ -36,8 +42,7 @@ export async function get({ params, query }) {
 
 // DELETE /api/v2/projects/{projectCode}/user/{username} - remove user from project
 // Security: must be user being removed, a project manager on the project in question, or a site admin
-// TODO: Add security check
-export async function del({ params, query }) {
+export async function del({ params, query, headers }) {
     if (!params || !params.projectCode) {
         return missingRequiredParam('projectCode', 'URL');
     }
@@ -45,31 +50,40 @@ export async function del({ params, query }) {
         return missingRequiredParam('username', 'URL');
     }
     const db = query.private ? dbs.private : dbs.public;
-    return removeUserFromProjectByProjectCode(db, params.projectCode, params.username);
+    const authResult = await allowSameUserOrProjectManagerOrAdmin(db, { params, headers });
+    if (authResult.status === 200) {
+        return removeUserFromProjectByProjectCode(db, params.projectCode, params.username);
+    } else {
+        return authResult;
+    }
 }
 
 // POST /api/v2/projects/{projectCode}/user/{username} - add user to project or update role
 // Role should be given in POST body; either a string or integer, or a JSON object with a `role`, `roleId`, or `roleName` property
 // If no role specified, defaults to Contributor
 // Security: must be user being removed, a project manager on the project in question, or a site admin
-// TODO: Add security check
-export async function post({ params, path, body, query }) {
+export async function post({ params, path, body, query, headers }) {
     if (!params.projectCode) {
         return missingRequiredParam('projectCode', path);
     }
     if (!params.username) {
         return missingRequiredParam('username', path);
     }
-    let roleName;
-    if (body && typeof body === "string") {
-        roleName = body;
-    } else if (body && typeof body === "number") {
-        roleName = body;
-    } else if (body && typeof body === "object") {
-        roleName = body.role ? body.role : body.roleId ? body.roleId : body.roleName ? body.roleName : defaultRoleId;
-    } else {
-        roleName = defaultRoleId;
-    }
     const db = query.private ? dbs.private : dbs.public;
-    return addUserWithRoleByProjectCode(db, params.projectCode, params.username, roleName);
+    const authResult = await allowSameUserOrProjectManagerOrAdmin(db, { params, headers });
+    if (authResult.status === 200) {
+        let roleName;
+        if (body && typeof body === "string") {
+            roleName = body;
+        } else if (body && typeof body === "number") {
+            roleName = body;
+        } else if (body && typeof body === "object") {
+            roleName = body.role ? body.role : body.roleId ? body.roleId : body.roleName ? body.roleName : defaultRoleId;
+        } else {
+            roleName = defaultRoleId;
+        }
+        return addUserWithRoleByProjectCode(db, params.projectCode, params.username, roleName);
+    } else {
+        return authResult;
+    }
 }

--- a/src/routes/api/v2/projects/[projectCode]/user/[username]/index.js
+++ b/src/routes/api/v2/projects/[projectCode]/user/[username]/index.js
@@ -4,7 +4,9 @@ import { missingRequiredParam } from '$lib/utils/commonErrors';
 import { onlyOne } from '$lib/utils/commonSqlHandlers';
 import { addUserWithRoleByProjectCode, removeUserFromProjectByProjectCode } from '$lib/utils/db/usersAndRoles';
 
-// GET /api/projects/{projectCode}/user/{username} - return user's role
+// GET /api/v2/projects/{projectCode}/user/{username} - return user's role
+// Security: must be user whose role is being looked up, a project manager on the project in question, or a site admin
+// TODO: Add security check
 export async function get({ params, query }) {
     if (!params || !params.projectCode) {
         return missingRequiredParam('projectCode', 'URL');
@@ -24,7 +26,7 @@ export async function get({ params, query }) {
     });
 }
 
-// TODO: HEAD /api/projects/{projectCode}/user/{username} - is user a member of the project?
+// TODO: HEAD /api/v2/projects/{projectCode}/user/{username} - is user a member of the project?
 // Possible return codes:
 // 200 if user is member of project (with any role)
 // 404 if he/she is not, or if user or project not found
@@ -32,7 +34,9 @@ export async function get({ params, query }) {
 //     return { status: 204, body: {} }
 // }
 
-// DELETE /api/projects/{projectCode}/user/{username} - remove user from project
+// DELETE /api/v2/projects/{projectCode}/user/{username} - remove user from project
+// Security: must be user being removed, a project manager on the project in question, or a site admin
+// TODO: Add security check
 export async function del({ params, query }) {
     if (!params || !params.projectCode) {
         return missingRequiredParam('projectCode', 'URL');
@@ -44,6 +48,11 @@ export async function del({ params, query }) {
     return removeUserFromProjectByProjectCode(db, params.projectCode, params.username);
 }
 
+// POST /api/v2/projects/{projectCode}/user/{username} - add user to project or update role
+// Role should be given in POST body; either a string or integer, or a JSON object with a `role`, `roleId`, or `roleName` property
+// If no role specified, defaults to Contributor
+// Security: must be user being removed, a project manager on the project in question, or a site admin
+// TODO: Add security check
 export async function post({ params, path, body, query }) {
     if (!params.projectCode) {
         return missingRequiredParam('projectCode', path);

--- a/src/routes/api/v2/projects/[projectCode]/user/[username]/withRole/[rolename]/index.js
+++ b/src/routes/api/v2/projects/[projectCode]/user/[username]/withRole/[rolename]/index.js
@@ -6,7 +6,6 @@ import { allowManagerOrAdmin } from '$lib/utils/db/authRules';
 // POST /api/v2/projects/{projectCode}/user/{username}/withRole/{rolename} - add or update user's role in project
 // rolename parameter should be a string like "Contributor" or "Manager", but integer IDs are also allowed
 // Security: only project managers or admins allowed
-// TODO: Move security check earlier in function so we can reject fast if not allowed
 export async function post({ params, path, query, headers }) {
     if (!params.projectCode) {
         return missingRequiredParam('projectCode', path);

--- a/src/routes/api/v2/projects/[projectCode]/user/[username]/withRole/[rolename]/index.js
+++ b/src/routes/api/v2/projects/[projectCode]/user/[username]/withRole/[rolename]/index.js
@@ -3,6 +3,10 @@ import { addUserWithRoleByProjectCode } from '$lib/utils/db/usersAndRoles';
 import { dbs } from '$lib/db/dbsetup';
 import { allowManagerOrAdmin } from '$lib/utils/db/authRules';
 
+// POST /api/v2/projects/{projectCode}/user/{username}/withRole/{rolename} - add or update user's role in project
+// rolename parameter should be a string like "Contributor" or "Manager", but integer IDs are also allowed
+// Security: only project managers or admins allowed
+// TODO: Move security check earlier in function so we can reject fast if not allowed
 export async function post({ params, path, query, headers }) {
     if (!params.projectCode) {
         return missingRequiredParam('projectCode', path);

--- a/src/routes/api/v2/projects/index.js
+++ b/src/routes/api/v2/projects/index.js
@@ -4,6 +4,9 @@ import { retryOnServerError } from '$lib/utils/commonSqlHandlers';
 import { verifyJwtAuth } from '$lib/utils/db/auth';
 import { getAllProjects, countAllProjectsQuery, createOneProject } from '$lib/utils/db/projects';
 
+// GET /api/v2/projects - return list of all projects
+// Security: must be a site admin (list of all projects could contain sensitive names)
+// TODO: Add security check
 export function get({ query }) {
     const db = query.private ? dbs.private : dbs.public;
     // URLSearchParams objects don't destructure well, so convert to a POJO
@@ -11,6 +14,9 @@ export function get({ query }) {
     return getAllProjects(db, queryParams);
 }
 
+// HEAD /api/v2/projects - return 200 if at least one project exists, 404 if zero projects
+// Security: must be a site admin (list of all projects could contain sensitive names)
+// TODO: Add security check
 export async function head({ query }) {
     const db = query.private ? dbs.private : dbs.public;
     const queryParams = Object.fromEntries(query);
@@ -19,6 +25,8 @@ export async function head({ query }) {
     return { status, body: {} };
 }
 
+// POST /api/v2/projects - create project, or update project if it aleady exists.
+// Security: anyone may create a project, and they become the project's first manager. Updating is restricted to existing project managers or site admins.
 export async function post({ path, body, query, headers }) {
     if (typeof body !== 'object') {
         return jsonRequired('POST', path);

--- a/src/routes/api/v2/projects/index.js
+++ b/src/routes/api/v2/projects/index.js
@@ -1,28 +1,36 @@
 import { dbs } from '$lib/db/dbsetup';
 import { jsonRequired, missingRequiredParam, authTokenRequired, notAllowed } from '$lib/utils/commonErrors';
 import { retryOnServerError } from '$lib/utils/commonSqlHandlers';
-import { verifyJwtAuth } from '$lib/utils/db/auth';
+import { allowAdminOnly } from '$lib/utils/db/authRules';
 import { getAllProjects, countAllProjectsQuery, createOneProject } from '$lib/utils/db/projects';
 
 // GET /api/v2/projects - return list of all projects
 // Security: must be a site admin (list of all projects could contain sensitive names)
-// TODO: Add security check
-export function get({ query }) {
+export async function get({ query, headers }) {
     const db = query.private ? dbs.private : dbs.public;
-    // URLSearchParams objects don't destructure well, so convert to a POJO
-    const queryParams = Object.fromEntries(query);
-    return getAllProjects(db, queryParams);
+    const authResult = await allowAdminOnly(db, { headers });
+    if (authResult.status === 200) {
+        // URLSearchParams objects don't destructure well, so convert to a POJO
+        const queryParams = Object.fromEntries(query);
+        return getAllProjects(db, queryParams);
+    } else {
+        return authResult;
+    }
 }
 
 // HEAD /api/v2/projects - return 200 if at least one project exists, 404 if zero projects
 // Security: must be a site admin (list of all projects could contain sensitive names)
-// TODO: Add security check
-export async function head({ query }) {
+export async function head({ query, headers }) {
     const db = query.private ? dbs.private : dbs.public;
-    const queryParams = Object.fromEntries(query);
-    const count = await retryOnServerError(countAllProjectsQuery(db, queryParams));
-    const status = count > 0 ? 200 : 404;
-    return { status, body: {} };
+    const authResult = await allowAdminOnly(db, { headers });
+    if (authResult.status === 200) {
+        const queryParams = Object.fromEntries(query);
+        const count = await retryOnServerError(countAllProjectsQuery(db, queryParams));
+        const status = count > 0 ? 200 : 404;
+        return { status, body: {} };
+    } else {
+        return { status: authResult.status, body: {} }
+    }
 }
 
 // POST /api/v2/projects - create project, or update project if it aleady exists.

--- a/src/routes/api/v2/roles.js
+++ b/src/routes/api/v2/roles.js
@@ -2,6 +2,8 @@ import { Role } from '$lib/db/models';
 import { dbs } from '$lib/db/dbsetup';
 import { retryOnServerError } from '$lib/utils/commonSqlHandlers';
 
+// GET /api/v2/roles - return list of all roles
+// Security: anonymous access allowed
 export async function get({ query }) {
     const db = query.private ? dbs.private : dbs.public;
     try {

--- a/src/routes/api/v2/search/projects/[searchTerm].js
+++ b/src/routes/api/v2/search/projects/[searchTerm].js
@@ -2,34 +2,39 @@ import { Project } from '$lib/db/models';
 import { dbs } from '$lib/db/dbsetup';
 import { missingRequiredParam } from '$lib/utils/commonErrors';
 import { catchSqlError } from '$lib/utils/commonSqlHandlers';
+import { allowAdminOnly } from '$lib/utils/db/authRules';
 
 // GET /api/v2/search/projects/{searchTerm} - search projects for text in project code, name, or description
 // Security: must be a site admin (searching for "a" could reveal nearly all projects, including some that could contain sensitive names)
-// TODO: Add security check
-export async function get({ params, query, path }) {
+export async function get({ params, query, headers, path }) {
     const db = query.private ? dbs.private : dbs.public;
-    if (!params.searchTerm) {
-        return missingRequiredParam('searchTerm', path);
+    const authResult = await allowAdminOnly(db, { headers });
+    if (authResult.status === 200) {
+        if (!params.searchTerm) {
+            return missingRequiredParam('searchTerm', path);
+        }
+        return catchSqlError(async () => {
+            let search = Project.query(db)
+                .where('identifier', 'like', `%${params.searchTerm}%`)
+                .orWhere('name', 'like', `%${params.searchTerm}%`)
+                .orWhere('description', 'like', `%${params.searchTerm}%`)
+                ;
+
+            const limit = query.get('limit');
+            if (limit) {
+                search = search.limit(limit);
+            }
+            const offset = query.get('offset');
+            if (offset) {
+                search = search.offset(offset);
+            }
+
+            const projects = await search;
+            return { status: 200, body: projects };
+        });
+    } else {
+        return authResult;
     }
-    return catchSqlError(async () => {
-        let search = Project.query(db)
-            .where('identifier', 'like', `%${params.searchTerm}%`)
-            .orWhere('name', 'like', `%${params.searchTerm}%`)
-            .orWhere('description', 'like', `%${params.searchTerm}%`)
-            ;
-
-        const limit = query.get('limit');
-        if (limit) {
-            search = search.limit(limit);
-        }
-        const offset = query.get('offset');
-        if (offset) {
-            search = search.offset(offset);
-        }
-
-        const projects = await search;
-        return { status: 200, body: projects };
-    });
 }
 
 // TODO: Consider adding ?withMembers as a query parameter to return membership records alongside the projects returned by the search

--- a/src/routes/api/v2/search/projects/[searchTerm].js
+++ b/src/routes/api/v2/search/projects/[searchTerm].js
@@ -3,6 +3,9 @@ import { dbs } from '$lib/db/dbsetup';
 import { missingRequiredParam } from '$lib/utils/commonErrors';
 import { catchSqlError } from '$lib/utils/commonSqlHandlers';
 
+// GET /api/v2/search/projects/{searchTerm} - search projects for text in project code, name, or description
+// Security: must be a site admin (searching for "a" could reveal nearly all projects, including some that could contain sensitive names)
+// TODO: Add security check
 export async function get({ params, query, path }) {
     const db = query.private ? dbs.private : dbs.public;
     if (!params.searchTerm) {

--- a/src/routes/api/v2/search/users/[searchTerm].js
+++ b/src/routes/api/v2/search/users/[searchTerm].js
@@ -5,6 +5,8 @@ import { catchSqlError } from '$lib/utils/commonSqlHandlers';
 import { verifyJwtAuth } from '$lib/utils/db/auth';
 import { isAdmin } from '$lib/utils/db/authRules';
 
+// GET /api/v2/search/users/{searchTerm} - search registered users for text in user's username, name, or email address
+// Security: anyone can search, but only admins get to see email addresses in the result
 export async function get({ params, query, path, headers }) {
     const db = query.private ? dbs.private : dbs.public;
     if (!params.searchTerm) {

--- a/src/routes/api/v2/users/[username]/index.js
+++ b/src/routes/api/v2/users/[username]/index.js
@@ -4,6 +4,8 @@ import { retryOnServerError } from '$lib/utils/commonSqlHandlers';
 import { allowSameUserOrAdmin } from '$lib/utils/db/authRules';
 import { getOneUser, oneUserQuery, patchUser, deleteUser, createUser } from '$lib/utils/db/users';
 
+// GET /api/v2/users/{username} - get details about one user
+// Security: must be user in question or a site admin
 export async function get({ params, path, query, headers }) {
     if (!params.username) {
         return missingRequiredParam('username', path);
@@ -17,6 +19,8 @@ export async function get({ params, path, query, headers }) {
     }
 }
 
+// HEAD /api/v2/users/{username} - check whether username already exists (200 if it does, 404 if it does not)
+// Security: anonymous access allowed
 export async function head({ params, query }) {
     if (!params.username) {
         return { status: 400, body: {} };
@@ -31,6 +35,8 @@ export async function head({ params, query }) {
     }
 }
 
+// PUT /api/v2/users/{username} - update or create details about one user (if update, update should be complete user record)
+// Security: must be user in question or a site admin
 export async function put({ path, params, body, query, headers }) {
     if (!params.username) {
         return missingRequiredParam('username', path);
@@ -52,6 +58,8 @@ export async function put({ path, params, body, query, headers }) {
     }
 }
 
+// PATCH /api/v2/users/{username} - update details about one user (details can be partial, e.g. {password: "newPassword"})
+// Security: must be user in question or a site admin
 export async function patch({ path, params, body, query, headers }) {
     if (!params.username) {
         return missingRequiredParam('username', path);
@@ -73,6 +81,8 @@ export async function patch({ path, params, body, query, headers }) {
     }
 }
 
+// DELETE /api/v2/users/{username} - unregister (delete) user from site
+// Security: must be user in question or a site admin
 export async function del({ params, path, query, headers }) {
     if (!params.username) {
         return missingRequiredParam('username', path);

--- a/src/routes/api/v2/users/[username]/isAdmin.js
+++ b/src/routes/api/v2/users/[username]/isAdmin.js
@@ -8,6 +8,8 @@ import { oneUserQuery } from '$lib/utils/db/users';
 // TODO: Consider whether this should be restricted to "only this user or admin", e.g. only allow checking *own* admin status, and not everyone's (although site admins can check everyone's status)
 export async function get({ query, params }) {
     const db = query.private ? dbs.private : dbs.public;
+    // const authResult = await allowSameUserOrAdmin(db, { params, headers });
+    // if (authResult.status === 200) {
     const users = await retryOnServerError(oneUserQuery(db, params.username).select('admin'));
     if (users && users.length > 0) {
         const result = await isAdmin(users[0]);
@@ -15,6 +17,9 @@ export async function get({ query, params }) {
     } else {
         return { status: 404, body: { isAdmin: false } };
     }
+    // } else {
+    //     return authResult;
+    // }
 }
 
 // HEAD /api/v2/users/{username}/isAdmin - returns 404 if user not found, 200 if user exists, but does nothing to tell you whether user is actually an admin

--- a/src/routes/api/v2/users/[username]/isAdmin.js
+++ b/src/routes/api/v2/users/[username]/isAdmin.js
@@ -3,6 +3,9 @@ import { retryOnServerError } from '$lib/utils/commonSqlHandlers';
 import { isAdmin } from '$lib/utils/db/authRules';
 import { oneUserQuery } from '$lib/utils/db/users';
 
+// GET /api/v2/users/{username}/isAdmin - check whether username in question is a site admin
+// Security: anonymous access allowed (used by Language Forge UI to check whether user should be shown LD admin pages)
+// TODO: Consider whether this should be restricted to "only this user or admin", e.g. only allow checking *own* admin status, and not everyone's (although site admins can check everyone's status)
 export async function get({ query, params }) {
     const db = query.private ? dbs.private : dbs.public;
     const users = await retryOnServerError(oneUserQuery(db, params.username).select('admin'));
@@ -14,6 +17,8 @@ export async function get({ query, params }) {
     }
 }
 
+// HEAD /api/v2/users/{username}/isAdmin - returns 404 if user not found, 200 if user exists, but does nothing to tell you whether user is actually an admin
+// TODO: Useless. Remove this.
 export async function head(req) {
     const { status, headers } = await get(req);
     return { status, headers, body: {} };

--- a/src/routes/api/v2/users/[username]/projects/index.js
+++ b/src/routes/api/v2/users/[username]/projects/index.js
@@ -3,6 +3,8 @@ import { missingRequiredParam } from '$lib/utils/commonErrors';
 import { allowSameUserOrAdmin } from '$lib/utils/db/authRules';
 import { getProjectsForUser } from '$lib/utils/db/usersAndRoles';
 
+// GET /api/v2/users/{username}/projects - List all projects a given user is a member of
+// Security: must be user in question or a site admin
 export async function get({ params, path, query, headers }) {
     if (!params.username) {
         return missingRequiredParam('username', path);

--- a/src/routes/api/v2/users/[username]/projects/withRole/[rolename].js
+++ b/src/routes/api/v2/users/[username]/projects/withRole/[rolename].js
@@ -3,6 +3,9 @@ import { missingRequiredParam } from '$lib/utils/commonErrors';
 import { allowSameUserOrAdmin } from '$lib/utils/db/authRules';
 import { getProjectsForUser } from '$lib/utils/db/usersAndRoles';
 
+// GET /api/v2/users/{username}/projects/withRole/{rolename} - Search for projects where given user has a specific role (e.g. "Manager")
+// rolename parameter should be a string like "Contributor" or "Manager", but integer IDs are also allowed
+// Security: must be user in question or a site admin
 export async function get({ params, path, query, headers }) {
     if (!params.username) {
         return missingRequiredParam('username', path);

--- a/src/routes/api/v2/users/index.js
+++ b/src/routes/api/v2/users/index.js
@@ -3,6 +3,9 @@ import { jsonRequired, missingRequiredParam } from '$lib/utils/commonErrors';
 import { retryOnServerError } from '$lib/utils/commonSqlHandlers';
 import { getAllUsers, countAllUsersQuery, createUser } from '$lib/utils/db/users';
 
+// GET /api/v2/users - return list of all users
+// Security: must be a site admin (list of all users could contain sensitive names or email addresses)
+// TODO: Add security check
 export async function get({ query }) {
     const db = query.private ? dbs.private : dbs.public;
     // URLSearchParams objects don't destructure well, so convert to a POJO
@@ -10,6 +13,9 @@ export async function get({ query }) {
     return getAllUsers(db, queryParams);
 }
 
+// HEAD /api/v2/users - return 200 if at least one user exists, 404 if zero users
+// Security: anonymous access allowed
+// TODO: Does this even make sense as an API call? Consider removing it.
 export async function head({ query }) {
     const db = query.private ? dbs.private : dbs.public;
     const queryParams = Object.fromEntries(query);
@@ -18,6 +24,9 @@ export async function head({ query }) {
     return { status, body: {} };
 }
 
+// POST /api/v2/users - create user, or update user if it aleady exists.
+// Security: anyone may create an account, but only that user (or a site admin) should be able to update the account details
+// TODO: Add security check (in createUser function) for "only same user or admin", because it's not there right now
 export async function post({ path, body, query }) {
     if (typeof body !== 'object') {
         return jsonRequired('POST', path);


### PR DESCRIPTION
Some API calls such as `/api/v2/users` should not allow anonymous access, otherwise we could leak sensitive info such as users' email addresses. Reviewed security permissions on all API endpoints and added permissions to the ones that should have been more restricted.