### PR TITLE
Work around Vite misfeature changing process.env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-ldapi",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"description": "An API for Language Depot, written in node.js",
 	"main": "build/index.js",
 	"author": "Robin Munn <robin_munn@sil.org>",

--- a/src/lib/utils/db/auth.js
+++ b/src/lib/utils/db/auth.js
@@ -38,8 +38,8 @@ export async function verifyBasicAuth(db, headers) {
     }
 }
 
-const jwtAudience = process.env.JWT_AUDIENCE || 'https://admin.languagedepot.org/api/v2';
-const signKey = process.env.JWT_SIGNING_KEY || 'not-a-secret';
+const jwtAudience = process.env['JWT_AUDIENCE'] || 'https://admin.languagedepot.org/api/v2';
+const signKey = process.env['JWT_SIGNING_KEY'] || 'not-a-secret';
 export function makeJwt(username) {
     var token = jwt.sign({
         sub: username,

--- a/test/loginUtils.js
+++ b/test/loginUtils.js
@@ -4,8 +4,8 @@ import jwt from 'jsonwebtoken'
 
 // Some tests will construct a JWT and make sure it's accepted by the server,
 // so make sure CI passes the same signing key and audience to the tests as the server
-const jwtAudience = process.env.JWT_AUDIENCE || 'https://admin.languagedepot.org/api/v2';
-const signKey = process.env.JWT_SIGNING_KEY || 'not-a-secret';
+const jwtAudience = process.env['JWT_AUDIENCE'] || 'https://admin.languagedepot.org/api/v2';
+const signKey = process.env['JWT_SIGNING_KEY'] || 'not-a-secret';
 function makeJwt(username) {
     var token = jwt.sign({
         sub: username,

--- a/test/testsetup.js
+++ b/test/testsetup.js
@@ -1,7 +1,7 @@
 import got from 'got';
 
-const API_HOST = process.env.API_HOST || 'localhost:3000';
-const API_SCHEME = process.env.API_SCHEME || 'http';
+const API_HOST = process.env['API_HOST'] || 'localhost:3000';
+const API_SCHEME = process.env['API_SCHEME'] || 'http';
 
 export const apiv2 = got.extend({
     prefixUrl: `${API_SCHEME}://${API_HOST}/api/v2/`,


### PR DESCRIPTION
Due to https://github.com/vitejs/vite/issues/3176, we have to use `process.env['FOO']` rather than `process.env.FOO`.