### PR TITLE
Simplify roleName assignment

### DIFF
--- a/src/routes/api/v2/projects/[projectCode]/user/[username]/index.js
+++ b/src/routes/api/v2/projects/[projectCode]/user/[username]/index.js
@@ -78,7 +78,7 @@ export async function post({ params, path, body, query, headers }) {
         } else if (body && typeof body === "number") {
             roleName = body;
         } else if (body && typeof body === "object") {
-            roleName = body.role ? body.role : body.roleId ? body.roleId : body.roleName ? body.roleName : defaultRoleId;
+            roleName = body.role || body.roleId || body.roleName || defaultRoleId;
         } else {
             roleName = defaultRoleId;
         }


### PR DESCRIPTION
Don't need a complicated chain of ternary operators here when simply using `||` will do the job just fine and be easier to read.